### PR TITLE
Develop

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -22,28 +22,18 @@ class IndexedCorpus:
     Attributes:
         documents: Original Document objects to store in the repository.
         processed_texts: Preprocessed text for each document (same order).
-<<<<<<< HEAD
             The indexer applies tokenization, lemmatization, stopword removal, etc.
         inverted_index: Mapping of term → list of (doc_index, term_frequency).
             Used to construct the TF-IDF matrix efficiently.
             Example: {'hipertensión': [(0, 2), (3, 1)], 'diabetes': [(1, 3), (2, 1)]}
         vocabulary: Ordered list of all unique terms. Maps term → term_index.
             This defines the column order of the TF-IDF matrix.
-=======
-            The indexer applies tokenization, stemming, stopword removal, etc.
-        vocabulary: Optional explicit term list. If None, TF-IDF discovers
-            the vocabulary automatically from processed_texts.
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
     """
 
     documents: list[Document]
     processed_texts: list[str]
-<<<<<<< HEAD
     inverted_index: dict[str, list[tuple[int, int]]]
     vocabulary: list[str]
-=======
-    vocabulary: list[str] | None = None
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 
     def __post_init__(self) -> None:
         if len(self.documents) != len(self.processed_texts):
@@ -107,10 +97,6 @@ class DocumentStore(ABC):
         """
         raise NotImplementedError
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
     def exists(self, doc_id: str) -> bool:
         """Check if a document exists without loading it.
 
@@ -140,11 +126,6 @@ class DocumentStore(ABC):
         """
         raise NotImplementedError("Delete not supported by this store")
 
-<<<<<<< HEAD
-=======
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 
 class BaseRepository(ABC):
     """Protocol for vector storage and similarity search.

--- a/docs/crawler-output-guide.md
+++ b/docs/crawler-output-guide.md
@@ -1,0 +1,108 @@
+# Crawler Output — Guide for the Indexer
+
+This document explains the format and location of the raw data produced by the
+crawler module, and how the indexer should consume it.
+
+## File location
+
+After running the crawler, one JSONL file is created per source inside `data/raw/`:
+
+```
+data/raw/
+    mayo_clinic.jsonl
+    medlineplus.jsonl
+    nhs.jsonl
+```
+
+Each file is appended to on every crawl run. Call `RawDocumentStorage.clear(source_name)`
+before a full re-crawl if you need to start fresh.
+
+## File format
+
+Each file follows the **JSONL** format — one JSON object per line, one line per document.
+
+```json
+{
+  "doc_id": "5e8ff578-d973-52e2-807d-1f71b80a5c84",
+  "text": "A congenital heart defect is a problem with the structure of the heart...",
+  "url": "https://www.mayoclinic.org/diseases-conditions/congenital-heart-defects/...",
+  "metadata": {
+    "title": "Congenital heart defects in children",
+    "source": "mayo_clinic",
+    "language": "en",
+    "date": "2024-01-15T00:00:00",
+    "category": "disease"
+  }
+}
+```
+
+### Field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `doc_id` | `str` | UUID5 derived from the URL. Stable across re-crawls — the same URL always produces the same ID. |
+| `text` | `str` | Clean article text with no HTML tags. Paragraphs separated by `\n\n`. This is the field to index. |
+| `url` | `str` | Canonical URL of the source page. |
+| `metadata.title` | `str` | Article title as it appears on the site. |
+| `metadata.source` | `str` | Source identifier: `"mayo_clinic"`, `"medlineplus"`, or `"nhs"`. |
+| `metadata.language` | `str` | ISO 639-1 language code: `"en"` or `"es"`. |
+| `metadata.date` | `str` | Last-modified or published date. Format varies by source (ISO 8601 when available). Empty string if unavailable. |
+| `metadata.category` | `str` | Broad topic tag. Values: `"disease"`, `"symptom"`, `"procedure"`, `"drug"`, `"wellness"`, `"mental-health"`, `"health-topic"`, `"reference"`. |
+
+## Reading the files in Python
+
+There is already a `DocumentLoader` at `modules/document_loader/service.py` —
+check it before writing your own loading code.
+
+If you need to read the files directly:
+
+```python
+import json
+from pathlib import Path
+from core.models import Document
+
+documents: list[Document] = []
+
+for path in Path("data/raw").glob("*.jsonl"):
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            record = json.loads(line)
+            documents.append(Document(
+                doc_id=record["doc_id"],
+                text=record["text"],
+                url=record["url"],
+                metadata=record["metadata"],
+            ))
+```
+
+## What the indexer needs
+
+The indexer only needs two fields to build the corpus:
+
+- **`text`** — the raw medical content to tokenize and vectorize.
+- **`doc_id`** — must be preserved as-is. It is the stable identifier that
+  connects a document across the entire pipeline (crawler → indexer → retriever → UI).
+
+The `metadata` fields are not used during indexing itself, but they must be
+stored alongside the vectors in ChromaDB so the retriever can return them with
+the search results.
+
+## Running the crawler
+
+```python
+from modules.crawler import CrawlerService, CrawlConfig
+from modules.crawler.scrapers.mayo_clinic import MayoClinicScraper
+from modules.crawler.scrapers.medlineplus import MedlinePlusScraper
+from modules.crawler.scrapers.nhs import NHSScraper
+
+result = CrawlerService(
+    scrapers=[MayoClinicScraper(), MedlinePlusScraper(), NHSScraper()],
+    config=CrawlConfig(delay_seconds=2.0),  # max_pages=None runs the full crawl
+).run()
+
+print(result)
+# CrawlResult(saved=..., visited=..., ok=..., failed=..., rate=...%, duration=...s)
+```
+
+> **Note:** The full crawl across all three sources will download several thousand
+> pages and take multiple hours. Use `max_pages=N` for testing.

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastructure layer: vector storage and raw document persistence."""
+
+from infra.storage import RawDocumentStorage, RawStorageError
+
+__all__ = ["RawDocumentStorage", "RawStorageError"]

--- a/infra/chroma_repository.py
+++ b/infra/chroma_repository.py
@@ -67,8 +67,6 @@ class ChromaRepository(BaseRepository):
 
         Returns:
             List of (doc_id, score) tuples ranked by relevance.
-<<<<<<< HEAD
-<<<<<<< HEAD
             Score is computed as 1 - distance (higher is better, range 0-1).
             Returns empty list if collection is empty or query fails.
         """
@@ -113,65 +111,5 @@ class ChromaRepository(BaseRepository):
             # Clamp to [0, 1] range for safety
             score = max(0.0, min(1.0, 1.0 - distance))
             ranked_results.append((doc_id, score))
-=======
-            Score is computed as 1 - distance (higher is better).
-=======
-            Score is computed as 1 - distance (higher is better, range 0-1).
-            Returns empty list if collection is empty or query fails.
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
-        """
-        try:
-            results = self.collection.query(
-                query_embeddings=[query_vector],
-                n_results=top_k,
-            )
-        except Exception as e:
-            # Log error and return empty results rather than crashing
-            import logging
-            logging.getLogger(__name__).error(f"ChromaDB query failed: {e}")
-            return []
-
-        ranked_results = []
-<<<<<<< HEAD
-        if results["ids"] and len(results["ids"][0]) > 0:
-            for i in range(len(results["ids"][0])):
-                doc_id = results["ids"][0][i]
-                # Convert distance to similarity score (1 - distance)
-                # ChromaDB uses cosine distance by default
-                score = 1.0 - results["distances"][0][i]
-                ranked_results.append((doc_id, score))
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-
-        # Validate response structure
-        if not results or not results.get("ids") or not results["ids"]:
-            return []
-
-        ids = results["ids"][0]
-        distances = results.get("distances", [[]])[0]
-
-        # Ensure we have matching lengths
-        if len(ids) != len(distances):
-            import logging
-            logging.getLogger(__name__).warning(
-                f"Mismatched results: {len(ids)} ids vs {len(distances)} distances"
-            )
-            return []
-
-        for i in range(len(ids)):
-            doc_id = ids[i]
-            distance = distances[i]
-
-            # Handle potential None or invalid distance values
-            if distance is None:
-                continue
-
-            # Convert distance to similarity score (1 - distance)
-            # ChromaDB uses cosine distance (0 = identical, 2 = opposite)
-            # Clamp to [0, 1] range for safety
-            score = max(0.0, min(1.0, 1.0 - distance))
-            ranked_results.append((doc_id, score))
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 
         return ranked_results
-

--- a/infra/storage.py
+++ b/infra/storage.py
@@ -1,0 +1,193 @@
+"""Raw document storage for crawler output.
+
+Persists Document objects to JSONL files in data/raw/, one file per source.
+Each line is a JSON object with the fields expected by DocumentLoader:
+    doc_id, text, url, metadata
+
+This module is the boundary between the crawler and the rest of the pipeline.
+The indexer reads these files later via DocumentLoader — the two never interact
+directly.
+
+Usage:
+    storage = RawDocumentStorage("data/raw")
+    written = storage.save_batch(documents, source_name="mayo_clinic")
+    # → writes/appends to data/raw/mayo_clinic.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from core.models import Document
+
+logger = logging.getLogger(__name__)
+
+
+class RawStorageError(Exception):
+    """Raised when a document cannot be persisted to raw storage."""
+
+    pass
+
+
+class RawDocumentStorage:
+    """Persists crawler documents as JSONL files in data/raw/.
+
+    One JSONL file is created per source (e.g., mayo_clinic.jsonl).
+    Each line is a JSON-serialized Document compatible with DocumentLoader.
+
+    Calling save_batch() appends to an existing file, which allows
+    incremental crawling (resume without re-downloading). Call clear()
+    first if a full re-crawl is needed.
+
+    Example:
+        storage = RawDocumentStorage("data/raw")
+
+        # Append a batch of documents from a single source
+        n = storage.save_batch(documents, source_name="mayo_clinic")
+        print(f"Saved {n} documents to mayo_clinic.jsonl")
+
+        # Re-crawl from scratch
+        storage.clear("mayo_clinic")
+        n = storage.save_batch(fresh_documents, source_name="mayo_clinic")
+    """
+
+    def __init__(self, output_dir: str = "data/raw") -> None:
+        """Initialize storage, creating the output directory if needed.
+
+        Args:
+            output_dir: Directory where JSONL files will be written.
+
+        Raises:
+            OSError: If the directory cannot be created.
+        """
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def source_path(self, source_name: str) -> Path:
+        """Return the JSONL file path for a given source.
+
+        Args:
+            source_name: Identifier for the source (e.g., "mayo_clinic").
+
+        Returns:
+            Path to the corresponding .jsonl file inside output_dir.
+        """
+        safe_name = source_name.strip().replace(" ", "_").lower()
+        return self.output_dir / f"{safe_name}.jsonl"
+
+    def save(self, document: Document, source_name: str) -> None:
+        """Append a single document to the source JSONL file.
+
+        Args:
+            document: Document to persist.
+            source_name: Source identifier (e.g., "mayo_clinic").
+
+        Raises:
+            RawStorageError: If the document cannot be written to disk.
+        """
+        path = self.source_path(source_name)
+        try:
+            record = self._to_record(document)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except TypeError as e:
+            raise RawStorageError(
+                f"Document '{document.doc_id}' contains non-serializable data: {e}"
+            ) from e
+        except OSError as e:
+            raise RawStorageError(
+                f"Cannot write document '{document.doc_id}' to '{path}': {e}"
+            ) from e
+
+    def save_batch(self, documents: list[Document], source_name: str) -> int:
+        """Append a batch of documents to the source JSONL file.
+
+        Opens the file once for the whole batch. Individual documents that
+        fail serialization are skipped and logged — they do not abort the
+        rest of the batch. An OSError (disk full, permissions) does abort.
+
+        Args:
+            documents: Documents to persist.
+            source_name: Source identifier (e.g., "mayo_clinic").
+
+        Returns:
+            Number of documents successfully written.
+
+        Raises:
+            RawStorageError: If the file cannot be opened for writing.
+        """
+        if not documents:
+            return 0
+
+        path = self.source_path(source_name)
+        written = 0
+
+        try:
+            with open(path, "a", encoding="utf-8") as f:
+                for doc in documents:
+                    try:
+                        record = self._to_record(doc)
+                        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+                        written += 1
+                    except TypeError as e:
+                        logger.warning(
+                            "Skipping document '%s': non-serializable data: %s",
+                            doc.doc_id,
+                            e,
+                        )
+        except OSError as e:
+            raise RawStorageError(
+                f"Cannot open '{path}' for writing: {e}"
+            ) from e
+
+        logger.info(
+            "Saved %d/%d documents → %s", written, len(documents), path
+        )
+        return written
+
+    def exists(self, source_name: str) -> bool:
+        """Check whether a JSONL file exists for the given source.
+
+        Args:
+            source_name: Source identifier.
+
+        Returns:
+            True if the JSONL file exists and is non-empty.
+        """
+        path = self.source_path(source_name)
+        return path.exists() and path.stat().st_size > 0
+
+    def clear(self, source_name: str) -> None:
+        """Delete the JSONL file for a source to allow a full re-crawl.
+
+        Silently does nothing if the file does not exist.
+
+        Args:
+            source_name: Source identifier.
+        """
+        path = self.source_path(source_name)
+        if path.exists():
+            path.unlink()
+            logger.info("Cleared raw storage for source '%s'", source_name)
+
+    @staticmethod
+    def _to_record(document: Document) -> dict:
+        """Serialize a Document to a dict compatible with DocumentLoader.
+
+        Args:
+            document: Document to serialize.
+
+        Returns:
+            Dict with doc_id, text, url, metadata keys.
+
+        Raises:
+            TypeError: If metadata contains non-JSON-serializable values.
+        """
+        return {
+            "doc_id": document.doc_id,
+            "text": document.text,
+            "url": document.url,
+            "metadata": document.metadata,
+        }

--- a/modules/crawler/__init__.py
+++ b/modules/crawler/__init__.py
@@ -2,18 +2,19 @@
 
 Public API
 ----------
-CrawlConfig   — parameters for a crawl session (delays, limits, output dir)
-CrawlResult   — statistics produced at the end of a crawl session
-BaseScraper   — ABC that every site-specific scraper must implement
+CrawlerService — single entry point: assemble scrapers + config and call run()
+CrawlConfig    — parameters for a crawl session (delays, limits, output dir)
+CrawlResult    — statistics produced at the end of a crawl session
+BaseScraper    — ABC that every site-specific scraper must implement
 
-Internal components (not exported here, imported directly when needed):
+Internal components (imported directly when needed):
     modules.crawler.crawler   — GenericCrawler (fetching, queue, robots.txt)
     modules.crawler.registry  — ScraperRegistry (domain → scraper mapping)
-    modules.crawler.service   — CrawlerService (single entry point)
     modules.crawler.scrapers  — concrete scraper implementations
 """
 
 from modules.crawler.base import BaseScraper
 from modules.crawler.models import CrawlConfig, CrawlResult
+from modules.crawler.service import CrawlerService
 
-__all__ = ["BaseScraper", "CrawlConfig", "CrawlResult"]
+__all__ = ["BaseScraper", "CrawlConfig", "CrawlResult", "CrawlerService"]

--- a/modules/crawler/__init__.py
+++ b/modules/crawler/__init__.py
@@ -1,0 +1,19 @@
+"""Crawler module for medical data acquisition.
+
+Public API
+----------
+CrawlConfig   — parameters for a crawl session (delays, limits, output dir)
+CrawlResult   — statistics produced at the end of a crawl session
+BaseScraper   — ABC that every site-specific scraper must implement
+
+Internal components (not exported here, imported directly when needed):
+    modules.crawler.crawler   — GenericCrawler (fetching, queue, robots.txt)
+    modules.crawler.registry  — ScraperRegistry (domain → scraper mapping)
+    modules.crawler.service   — CrawlerService (single entry point)
+    modules.crawler.scrapers  — concrete scraper implementations
+"""
+
+from modules.crawler.base import BaseScraper
+from modules.crawler.models import CrawlConfig, CrawlResult
+
+__all__ = ["BaseScraper", "CrawlConfig", "CrawlResult"]

--- a/modules/crawler/base.py
+++ b/modules/crawler/base.py
@@ -1,0 +1,116 @@
+"""Abstract base class for site-specific scrapers.
+
+Each scraper targets a single medical website and knows how to extract
+structured content from its HTML pages. The generic crawler handles
+everything else: HTTP fetching, robots.txt, delays, queuing, and persistence.
+
+Scrapers must store all site-specific knowledge (CSS selectors, URL patterns,
+language detection logic) inside the subclass. The crawler never reaches
+into scraper internals.
+
+Metadata contract
+-----------------
+The Document returned by scrape() must populate doc.metadata with at least
+these keys so that downstream modules (indexer, ranker, UI) can filter and
+display results correctly:
+
+    title     (str)  — page title as it appears on the site
+    source    (str)  — matches source_name (e.g., "mayo_clinic")
+    language  (str)  — ISO 639-1 code: "en" or "es"
+    date      (str)  — publication or last-modified date, ISO 8601 if known,
+                       empty string if not available
+    category  (str)  — broad topic tag (e.g., "disease", "symptom", "drug",
+                       "wellness"), site-specific but consistent within a scraper
+
+Additional keys are allowed. Unknown keys are ignored by the pipeline.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from core.models import Document
+
+
+class BaseScraper(ABC):
+    """Contract for site-specific HTML scrapers.
+
+    The generic crawler calls can_handle() to select the right scraper
+    for a URL, then calls scrape() to extract a Document. The scraper
+    never performs HTTP requests — it only parses HTML already fetched
+    by the crawler.
+
+    Subclass checklist:
+        1. Set ``domain`` to the hostname (e.g., "www.mayoclinic.org").
+        2. Set ``source_name`` to the snake_case source identifier
+           (e.g., "mayo_clinic"). This becomes the JSONL filename.
+        3. Implement ``scrape()`` to parse HTML and return a Document
+           with the required metadata keys (see module docstring).
+        4. Return None from ``scrape()`` for pages with no useful content
+           (index pages, login walls, 404 pages, etc.).
+        5. Override ``can_handle()`` if domain-level matching is insufficient
+           (e.g., you only handle a specific path prefix).
+
+    Example:
+        class MayoClinicScraper(BaseScraper):
+            domain = "www.mayoclinic.org"
+            source_name = "mayo_clinic"
+
+            def scrape(self, url: str, html: str) -> Document | None:
+                soup = BeautifulSoup(html, "lxml")
+                ...
+    """
+
+    #: Hostname this scraper handles, without scheme (e.g., "www.mayoclinic.org").
+    #: Must be set as a class attribute in every subclass.
+    domain: str
+
+    #: Snake_case identifier used as the JSONL filename in data/raw/.
+    #: Must be set as a class attribute in every subclass.
+    source_name: str
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Enforce that subclasses declare domain and source_name."""
+        super().__init_subclass__(**kwargs)
+        if not getattr(cls, "domain", None):
+            raise TypeError(
+                f"{cls.__name__} must define a non-empty class attribute 'domain'"
+            )
+        if not getattr(cls, "source_name", None):
+            raise TypeError(
+                f"{cls.__name__} must define a non-empty class attribute 'source_name'"
+            )
+
+    @abstractmethod
+    def scrape(self, url: str, html: str) -> Document | None:
+        """Extract a Document from the raw HTML of a page.
+
+        Args:
+            url: Canonical URL of the page (already fetched by the crawler).
+            html: Raw HTML content as a string.
+
+        Returns:
+            A populated Document if the page contains useful medical content.
+            None if the page should be skipped (index, error, login, etc.).
+
+        Note:
+            The returned Document must have metadata keys:
+            title, source, language, date, category.
+            See module docstring for the full contract.
+        """
+        ...
+
+    def can_handle(self, url: str) -> bool:
+        """Check whether this scraper should process a given URL.
+
+        The default implementation checks whether self.domain appears
+        anywhere in the URL string. Override for stricter matching
+        (e.g., only handle URLs under /diseases-conditions/).
+
+        Args:
+            url: URL to evaluate.
+
+        Returns:
+            True if this scraper can extract content from the URL.
+        """
+        return self.domain in url

--- a/modules/crawler/base.py
+++ b/modules/crawler/base.py
@@ -44,17 +44,23 @@ class BaseScraper(ABC):
         1. Set ``domain`` to the hostname (e.g., "www.mayoclinic.org").
         2. Set ``source_name`` to the snake_case source identifier
            (e.g., "mayo_clinic"). This becomes the JSONL filename.
-        3. Implement ``scrape()`` to parse HTML and return a Document
+        3. Set ``sitemap_urls`` to the list of XML sitemaps for this source.
+           Override ``get_sitemap_urls()`` instead if the list must be built
+           at runtime.
+        4. Implement ``scrape()`` to parse HTML and return a Document
            with the required metadata keys (see module docstring).
-        4. Return None from ``scrape()`` for pages with no useful content
+        5. Return None from ``scrape()`` for pages with no useful content
            (index pages, login walls, 404 pages, etc.).
-        5. Override ``can_handle()`` if domain-level matching is insufficient
+        6. Override ``can_handle()`` if domain-level matching is insufficient
            (e.g., you only handle a specific path prefix).
 
     Example:
         class MayoClinicScraper(BaseScraper):
             domain = "www.mayoclinic.org"
             source_name = "mayo_clinic"
+            sitemap_urls = [
+                "https://www.mayoclinic.org/sitemap/condition_consolidated_concepts.xml",
+            ]
 
             def scrape(self, url: str, html: str) -> Document | None:
                 soup = BeautifulSoup(html, "lxml")
@@ -68,6 +74,10 @@ class BaseScraper(ABC):
     #: Snake_case identifier used as the JSONL filename in data/raw/.
     #: Must be set as a class attribute in every subclass.
     source_name: str
+
+    #: XML sitemap URLs the crawler should fetch to discover article URLs.
+    #: Override get_sitemap_urls() when the list must be built at runtime.
+    sitemap_urls: list[str] = []
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         """Enforce that subclasses declare domain and source_name."""
@@ -99,6 +109,19 @@ class BaseScraper(ABC):
             See module docstring for the full contract.
         """
         ...
+
+    def get_sitemap_urls(self) -> list[str]:
+        """Return the sitemap URLs used to seed the crawl for this source.
+
+        The default implementation returns a copy of the ``sitemap_urls``
+        class attribute. Override this method when the URL list must be
+        constructed at runtime (e.g., paginated sitemaps, date-range feeds).
+
+        Returns:
+            List of absolute XML sitemap URLs (urlset or sitemapindex format).
+            Return an empty list if this scraper does not use sitemaps.
+        """
+        return list(self.sitemap_urls)
 
     def can_handle(self, url: str) -> bool:
         """Check whether this scraper should process a given URL.

--- a/modules/crawler/crawler.py
+++ b/modules/crawler/crawler.py
@@ -1,0 +1,490 @@
+"""Generic crawler for medical website data acquisition.
+
+The crawler owns all I/O: HTTP sessions, robots.txt enforcement, delay
+scheduling, sitemap parsing, and persistence. It contains no site-specific
+HTML parsing logic — that responsibility belongs entirely to BaseScraper
+subclasses.
+
+Crawl strategy
+--------------
+URL discovery is sitemap-only. The crawler fetches each scraper's declared
+sitemaps, expands them (including sitemapindex → urlset recursion), and
+builds a flat queue of (url, scraper) pairs. Link-following from crawled
+pages is intentionally NOT implemented; sitemaps are authoritative for all
+three target sources.
+
+Deduplication
+-------------
+A ``visited_urls`` set prevents re-fetching URLs that appear in multiple
+sitemaps or in sitemap indexes that reference overlapping urlsets.
+
+doc_id assignment
+-----------------
+The crawler always overwrites the doc_id on returned Documents with a
+UUID5 derived from the URL. This makes IDs stable across re-crawls and
+independent of what each scraper chose to put in the field.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections import deque
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import requests
+from bs4 import BeautifulSoup
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from core.models import Document
+from infra.storage import RawDocumentStorage, RawStorageError
+from modules.crawler.base import BaseScraper
+from modules.crawler.models import CrawlConfig, CrawlResult
+from modules.crawler.registry import ScraperRegistry
+
+logger = logging.getLogger(__name__)
+
+# Flush accumulated documents to storage every N docs per source.
+_BATCH_FLUSH_SIZE: int = 50
+
+# Maximum recursion depth when expanding sitemapindex files.
+_MAX_SITEMAP_DEPTH: int = 3
+
+
+class GenericCrawler:
+    """HTTP-first crawler that delegates HTML parsing to site-specific scrapers.
+
+    The crawler owns all I/O: HTTP sessions, robots.txt enforcement, delay
+    scheduling, sitemap parsing, and persistence. It never contains
+    site-specific HTML parsing logic.
+
+    Lifecycle:
+        1. ``__init__``: receive scrapers, config, storage; build registry.
+        2. ``crawl()``: seed URL queue from sitemaps, drain the queue
+           page by page, store results incrementally.
+
+    Thread-safety:
+        Not thread-safe. ``crawl()`` is a single-threaded sequential loop.
+        Concurrent crawling would complicate robots.txt enforcement and
+        rate-limiting without meaningful gain for an academic corpus.
+
+    Example:
+        config = CrawlConfig(max_pages=500)
+        crawler = GenericCrawler(
+            scrapers=[MayoClinicScraper()],
+            config=config,
+            storage=RawDocumentStorage("data/raw"),
+        )
+        result = crawler.crawl()
+        print(result)
+    """
+
+    def __init__(
+        self,
+        scrapers: list[BaseScraper],
+        config: CrawlConfig,
+        storage: RawDocumentStorage,
+    ) -> None:
+        """Initialize the crawler.
+
+        Args:
+            scrapers: Site-specific scraper instances. Each must have
+                ``domain``, ``source_name``, and ``get_sitemap_urls()`` set.
+            config: Controls delays, page limits, robots.txt, timeouts.
+            storage: Where crawled documents are persisted as JSONL.
+        """
+        self._config = config
+        self._storage = storage
+        self._registry = ScraperRegistry()
+        for scraper in scrapers:
+            self._registry.register(scraper)
+
+        # Per-domain robots.txt cache: domain → RobotFileParser
+        self._robots_cache: dict[str, RobotFileParser] = {}
+
+        # Per-domain last-request timestamp for delay enforcement
+        self._last_request_time: dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def crawl(self) -> CrawlResult:
+        """Execute the full crawl and return a summary.
+
+        Steps:
+            1. Build an HTTP session with retry policy and User-Agent.
+            2. For every registered scraper, fetch its sitemaps and expand
+               them into a queue of (url, scraper) pairs.
+            3. Drain the queue: check robots.txt, enforce delay, fetch HTML,
+               call scraper.scrape(), persist Documents, update counters.
+            4. Flush any remaining per-source document batches.
+            5. Return a CrawlResult with final statistics.
+
+        Returns:
+            CrawlResult summarising the session.
+
+        Note:
+            No individual failure aborts the crawl. HTTP errors, parse
+            errors, and scraper exceptions are logged and counted as
+            failures. Only storage I/O errors (disk full, permissions) can
+            interrupt the loop, and even then only for the current batch.
+        """
+        start_time = time.monotonic()
+
+        # Counters
+        total_visited: int = 0
+        total_successful: int = 0
+        total_failed: int = 0
+        documents_saved: int = 0
+        errors: list[tuple[str, str]] = []
+
+        # Per-source document accumulator: source_name → [Document, ...]
+        batches: dict[str, list[Document]] = {}
+
+        session = self._setup_session()
+
+        # --- Phase 1: build the crawl queue from sitemaps ---
+        queue: deque[tuple[str, BaseScraper]] = deque()
+        visited_urls: set[str] = set()
+
+        for scraper in self._registry.all_scrapers():
+            sitemap_urls = scraper.get_sitemap_urls()
+            if not sitemap_urls:
+                logger.warning(
+                    "Scraper '%s' has no sitemap URLs — nothing to crawl",
+                    type(scraper).__name__,
+                )
+                continue
+
+            for sitemap_url in sitemap_urls:
+                pairs = self._collect_urls_from_sitemap(
+                    sitemap_url, scraper, session
+                )
+                for url, s in pairs:
+                    if url not in visited_urls:
+                        visited_urls.add(url)
+                        queue.append((url, s))
+
+            logger.info(
+                "Scraper '%s': %d unique URLs queued from %d sitemap(s)",
+                type(scraper).__name__,
+                sum(1 for _, s in queue if s is scraper),
+                len(sitemap_urls),
+            )
+
+        logger.info("Total URLs in crawl queue: %d", len(queue))
+
+        # --- Phase 2: drain the queue ---
+        while queue:
+            if self._config.max_pages is not None and total_visited >= self._config.max_pages:
+                logger.info(
+                    "Reached max_pages limit (%d). Stopping crawl.",
+                    self._config.max_pages,
+                )
+                break
+
+            url, scraper = queue.popleft()
+            domain = urlparse(url).netloc
+
+            # robots.txt check
+            if self._config.respect_robots:
+                if not self._is_allowed_by_robots(url, session):
+                    logger.debug("robots.txt: disallowed — skipping %s", url)
+                    continue
+
+            # Delay
+            self._wait_for_domain(domain)
+
+            # Fetch
+            html = self._fetch(url, session)
+            total_visited += 1
+
+            if html is None:
+                total_failed += 1
+                errors.append((url, "HTTP fetch failed"))
+                continue
+
+            # Scrape
+            try:
+                document = scraper.scrape(url, html)
+            except Exception as exc:
+                logger.warning("Scraper error on %s: %s", url, exc)
+                total_failed += 1
+                errors.append((url, f"Scraper exception: {exc}"))
+                continue
+
+            if document is None:
+                # Valid skip — page had no useful content
+                logger.debug("Scraper returned None for %s — skipped", url)
+                total_failed += 1
+                continue
+
+            # Assign stable doc_id
+            document = Document(
+                doc_id=self._generate_doc_id(url),
+                text=document.text,
+                url=document.url or url,
+                metadata=document.metadata,
+            )
+
+            total_successful += 1
+
+            # Accumulate in batch
+            source = scraper.source_name
+            batches.setdefault(source, []).append(document)
+
+            # Incremental flush
+            if len(batches[source]) >= _BATCH_FLUSH_SIZE:
+                saved = self._flush_batch(batches[source], source)
+                documents_saved += saved
+                batches[source] = []
+
+        # --- Phase 3: final flush ---
+        for source, docs in batches.items():
+            if docs:
+                saved = self._flush_batch(docs, source)
+                documents_saved += saved
+
+        duration = time.monotonic() - start_time
+
+        result = CrawlResult(
+            documents_saved=documents_saved,
+            total_visited=total_visited,
+            total_successful=total_successful,
+            total_failed=total_failed,
+            errors=errors,
+            duration_seconds=duration,
+        )
+        logger.info("Crawl complete. %s", result)
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _setup_session(self) -> requests.Session:
+        """Create and configure the HTTP session with retry policy.
+
+        Retries up to 3 times on transient server errors (429, 500, 502,
+        503, 504) with exponential backoff. All other errors are handled
+        at the call site.
+
+        Returns:
+            Configured requests.Session ready for use.
+        """
+        session = requests.Session()
+        session.headers.update({"User-Agent": self._config.user_agent})
+
+        retry = Retry(
+            total=3,
+            backoff_factor=0.5,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET"],
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
+
+    def _collect_urls_from_sitemap(
+        self,
+        sitemap_url: str,
+        scraper: BaseScraper,
+        session: requests.Session,
+        depth: int = 0,
+    ) -> list[tuple[str, BaseScraper]]:
+        """Fetch and parse a sitemap, returning (url, scraper) pairs.
+
+        Handles both sitemap formats:
+            - ``<urlset>``: leaf sitemap; extract all ``<loc>`` elements.
+            - ``<sitemapindex>``: index sitemap; recursively fetch each
+              child sitemap up to ``_MAX_SITEMAP_DEPTH``.
+
+        Only URLs for which ``scraper.can_handle(url)`` returns True are
+        included. robots.txt is NOT checked for sitemap URLs themselves.
+
+        Args:
+            sitemap_url: Absolute URL of the sitemap XML.
+            scraper: Scraper instance associated with this sitemap.
+            session: Active HTTP session.
+            depth: Current recursion depth (caller passes 0).
+
+        Returns:
+            List of (article_url, scraper) pairs ready to enqueue.
+            Returns an empty list on any fetch or parse error.
+        """
+        if depth > _MAX_SITEMAP_DEPTH:
+            logger.warning(
+                "Sitemap recursion depth exceeded at %s — stopping", sitemap_url
+            )
+            return []
+
+        try:
+            response = session.get(
+                sitemap_url, timeout=self._config.request_timeout
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            logger.warning("Failed to fetch sitemap %s: %s", sitemap_url, exc)
+            return []
+
+        try:
+            soup = BeautifulSoup(response.text, "xml")
+        except Exception as exc:
+            logger.warning("Failed to parse sitemap %s: %s", sitemap_url, exc)
+            return []
+
+        # sitemapindex → recurse into child sitemaps
+        if soup.find("sitemapindex"):
+            results: list[tuple[str, BaseScraper]] = []
+            child_locs = soup.find_all("sitemap")
+            for child in child_locs:
+                loc_tag = child.find("loc")
+                if loc_tag and loc_tag.text:
+                    child_url = loc_tag.text.strip()
+                    results.extend(
+                        self._collect_urls_from_sitemap(
+                            child_url, scraper, session, depth + 1
+                        )
+                    )
+            return results
+
+        # urlset → extract article URLs
+        pairs: list[tuple[str, BaseScraper]] = []
+        url_tags = soup.find_all("url")
+        for tag in url_tags:
+            loc_tag = tag.find("loc")
+            if not loc_tag or not loc_tag.text:
+                continue
+            article_url = loc_tag.text.strip()
+            if scraper.can_handle(article_url):
+                pairs.append((article_url, scraper))
+
+        logger.debug(
+            "Sitemap %s → %d URLs (depth=%d)", sitemap_url, len(pairs), depth
+        )
+        return pairs
+
+    def _is_allowed_by_robots(
+        self, url: str, session: requests.Session
+    ) -> bool:
+        """Check whether url is allowed by the domain's robots.txt.
+
+        Fetches robots.txt once per domain and caches the result.
+        Fails open: if robots.txt cannot be fetched or parsed, the URL
+        is assumed to be allowed.
+
+        Args:
+            url: URL to check.
+            session: Active HTTP session (used only on cache miss).
+
+        Returns:
+            True if the URL may be fetched, False if disallowed.
+        """
+        parsed = urlparse(url)
+        domain = parsed.netloc
+        scheme = parsed.scheme
+
+        if domain not in self._robots_cache:
+            robots_url = f"{scheme}://{domain}/robots.txt"
+            parser = RobotFileParser()
+            parser.set_url(robots_url)
+            try:
+                response = session.get(
+                    robots_url, timeout=self._config.request_timeout
+                )
+                parser.parse(response.text.splitlines())
+            except Exception as exc:
+                logger.warning(
+                    "Could not fetch robots.txt for %s: %s — assuming allowed",
+                    domain,
+                    exc,
+                )
+            self._robots_cache[domain] = parser
+
+        return self._robots_cache[domain].can_fetch(
+            self._config.user_agent, url
+        )
+
+    def _fetch(self, url: str, session: requests.Session) -> str | None:
+        """Perform an HTTP GET and return the response body as a string.
+
+        Args:
+            url: Absolute URL to fetch.
+            session: Active HTTP session.
+
+        Returns:
+            HTML string on HTTP 200, None on any error.
+        """
+        try:
+            response = session.get(url, timeout=self._config.request_timeout)
+            response.raise_for_status()
+            return response.text
+        except requests.HTTPError as exc:
+            logger.warning("HTTP error fetching %s: %s", url, exc)
+        except requests.Timeout:
+            logger.warning("Timeout fetching %s", url)
+        except requests.ConnectionError as exc:
+            logger.warning("Connection error fetching %s: %s", url, exc)
+        except requests.RequestException as exc:
+            logger.warning("Request failed for %s: %s", url, exc)
+        return None
+
+    def _wait_for_domain(self, domain: str) -> None:
+        """Enforce the configured inter-request delay for a domain.
+
+        Tracks the timestamp of the last request per domain. Sleeps for
+        the remaining time if the delay has not yet elapsed.
+
+        Args:
+            domain: Hostname (e.g., "www.mayoclinic.org").
+        """
+        now = time.monotonic()
+        last = self._last_request_time.get(domain)
+        if last is not None:
+            elapsed = now - last
+            wait = self._config.delay_seconds - elapsed
+            if wait > 0:
+                time.sleep(wait)
+        self._last_request_time[domain] = time.monotonic()
+
+    def _flush_batch(self, docs: list[Document], source_name: str) -> int:
+        """Persist a batch of documents, returning the count saved.
+
+        Args:
+            docs: Documents to persist.
+            source_name: JSONL file identifier.
+
+        Returns:
+            Number of documents successfully written.
+        """
+        try:
+            return self._storage.save_batch(docs, source_name)
+        except RawStorageError as exc:
+            logger.error(
+                "Storage failure for source '%s': %s — %d documents lost",
+                source_name,
+                exc,
+                len(docs),
+            )
+            return 0
+
+    @staticmethod
+    def _generate_doc_id(url: str) -> str:
+        """Generate a stable, unique document ID from a URL.
+
+        Uses UUID5 with the URL as the name. Re-crawling the same URL
+        produces the same doc_id, enabling deduplication downstream.
+
+        Args:
+            url: Canonical URL of the page.
+
+        Returns:
+            UUID5 string (lowercase, hyphenated).
+        """
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, url))

--- a/modules/crawler/models.py
+++ b/modules/crawler/models.py
@@ -1,0 +1,80 @@
+"""Data models exclusive to the crawler module.
+
+Only CrawlConfig and CrawlResult are defined here.
+The Document model is imported from core.models — never redefined in this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CrawlConfig:
+    """Configuration for a crawl session.
+
+    Attributes:
+        user_agent: HTTP User-Agent header sent with every request.
+        delay_seconds: Minimum delay between consecutive requests to the
+            same domain. Applies both between sitemap URLs and between
+            article pages.
+        max_pages: Maximum number of pages to fetch across all sources.
+            None means no limit (crawl everything in the queue).
+        output_dir: Directory where JSONL files will be written.
+        respect_robots: If True, the crawler parses each domain's robots.txt
+            and skips any disallowed URL before fetching.
+        request_timeout: HTTP read timeout in seconds. Requests exceeding
+            this limit are aborted and counted as failures.
+    """
+
+    user_agent: str = "MedSRIBot/1.0 (proyecto académico UH)"
+    delay_seconds: float = 2.0
+    max_pages: int | None = None
+    output_dir: str = "data/raw"
+    respect_robots: bool = True
+    request_timeout: int = 15
+
+
+@dataclass
+class CrawlResult:
+    """Summary of a completed crawl session.
+
+    Attributes:
+        documents_saved: Number of documents successfully written to disk.
+        total_visited: Total URLs attempted (fetched from the network).
+        total_successful: URLs that produced a valid Document.
+        total_failed: URLs that returned an HTTP error, a network error,
+            or whose content the scraper could not parse.
+        errors: List of (url, error_message) pairs for every failed URL.
+            Useful for debugging and for resuming interrupted crawls.
+        duration_seconds: Wall-clock time for the entire crawl session.
+    """
+
+    documents_saved: int
+    total_visited: int
+    total_successful: int
+    total_failed: int
+    errors: list[tuple[str, str]] = field(default_factory=list)
+    duration_seconds: float = 0.0
+
+    @property
+    def success_rate(self) -> float:
+        """Fraction of visited URLs that produced a valid document.
+
+        Returns:
+            Value in [0.0, 1.0]. Returns 0.0 if no URLs were visited.
+        """
+        if self.total_visited == 0:
+            return 0.0
+        return self.total_successful / self.total_visited
+
+    def __str__(self) -> str:
+        return (
+            f"CrawlResult("
+            f"saved={self.documents_saved}, "
+            f"visited={self.total_visited}, "
+            f"ok={self.total_successful}, "
+            f"failed={self.total_failed}, "
+            f"rate={self.success_rate:.1%}, "
+            f"duration={self.duration_seconds:.1f}s)"
+        )

--- a/modules/crawler/registry.py
+++ b/modules/crawler/registry.py
@@ -1,0 +1,88 @@
+"""Scraper registry: maps URLs to the correct site-specific scraper.
+
+The registry is populated once at startup and consulted by GenericCrawler
+for every URL it is about to process.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from modules.crawler.base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+
+class ScraperRegistry:
+    """Maps a URL to the first registered scraper that can handle it.
+
+    Scrapers are evaluated in registration order. The first scraper whose
+    ``can_handle(url)`` returns True is selected. This means registration
+    order matters when scrapers have overlapping domains.
+
+    Example:
+        registry = ScraperRegistry()
+        registry.register(MayoClinicScraper())
+        registry.register(MedlinePlusScraper())
+
+        scraper = registry.get("https://www.mayoclinic.org/diseases-conditions/...")
+        # → MayoClinicScraper instance
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty registry."""
+        self._scrapers: list[BaseScraper] = []
+
+    def register(self, scraper: BaseScraper) -> None:
+        """Add a scraper to the registry.
+
+        Args:
+            scraper: Instantiated scraper to register.
+
+        Raises:
+            TypeError: If scraper is not a BaseScraper instance.
+        """
+        if not isinstance(scraper, BaseScraper):
+            raise TypeError(
+                f"Expected a BaseScraper instance, got {type(scraper).__name__}"
+            )
+        self._scrapers.append(scraper)
+        logger.debug(
+            "Registered scraper '%s' for domain '%s'",
+            type(scraper).__name__,
+            scraper.domain,
+        )
+
+    def get(self, url: str) -> BaseScraper | None:
+        """Return the first registered scraper that can handle url.
+
+        Iterates in registration order and calls ``scraper.can_handle(url)``.
+
+        Args:
+            url: Absolute URL to match.
+
+        Returns:
+            First matching scraper, or None if no scraper matches.
+        """
+        for scraper in self._scrapers:
+            if scraper.can_handle(url):
+                return scraper
+        return None
+
+    def all_scrapers(self) -> list[BaseScraper]:
+        """Return a snapshot of all registered scrapers in registration order.
+
+        Used by GenericCrawler to collect sitemap URLs at startup.
+
+        Returns:
+            List of all registered scrapers.
+        """
+        return list(self._scrapers)
+
+    def __len__(self) -> int:
+        """Return the number of registered scrapers."""
+        return len(self._scrapers)
+
+    def __repr__(self) -> str:
+        names = [type(s).__name__ for s in self._scrapers]
+        return f"ScraperRegistry({names})"

--- a/modules/crawler/scrapers/__init__.py
+++ b/modules/crawler/scrapers/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete scraper implementations for each medical source."""

--- a/modules/crawler/scrapers/mayo_clinic.py
+++ b/modules/crawler/scrapers/mayo_clinic.py
@@ -1,0 +1,289 @@
+"""Mayo Clinic scraper for medical content acquisition.
+
+Extracts structured content from Mayo Clinic article pages using the
+AEM (Adobe Experience Manager) component structure found in the site.
+
+Supported content sections (via sitemap — sourced from robots.txt):
+    English:  Diseases & Conditions, Symptoms, Articles, FAQ, Drugs, Procedures
+    Spanish:  Diseases & Conditions, Articles, FAQ, Procedures
+
+URL filtering:
+    Only URLs under known medical content paths are processed.
+    Appointment, career, and administrative pages are rejected by
+    can_handle() before any fetch occurs.
+
+Metadata produced per document:
+    title     — article title from the single <h1> in #main-content
+    source    — "mayo_clinic"
+    language  — ISO 639-1 code read from <html lang="...">
+    date      — ISO 8601 date from meta tags, or "" if unavailable
+    category  — topic tag inferred from URL path segment
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from core.models import Document
+from modules.crawler.base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# Maps URL path segment → category label stored in metadata.
+_CATEGORY_MAP: dict[str, str] = {
+    "diseases-conditions": "disease",
+    "symptoms": "symptom",
+    "tests-procedures": "procedure",
+    "drugs-supplements": "drug",
+    "healthy-lifestyle": "wellness",
+}
+
+# URL path prefixes that contain actual medical content.
+# Any URL NOT starting with one of these is rejected by can_handle().
+_CONTENT_PATHS: tuple[str, ...] = (
+    "/diseases-conditions/",
+    "/symptoms/",
+    "/tests-procedures/",
+    "/drugs-supplements/",
+    "/healthy-lifestyle/",
+    "/es/diseases-conditions/",
+    "/es/symptoms/",
+    "/es/tests-procedures/",
+    "/es/drugs-supplements/",
+    "/es/healthy-lifestyle/",
+)
+
+# Minimum character count for the extracted text to be considered valid.
+_MIN_CONTENT_LENGTH: int = 50
+
+# Meta tag names/properties to try when looking for the article date,
+# checked in order — first match wins.
+_DATE_META_ATTRS: tuple[dict[str, str], ...] = (
+    {"name": "article:modified_time"},
+    {"property": "article:modified_time"},
+    {"name": "article:published_time"},
+    {"property": "article:published_time"},
+    {"property": "og:updated_time"},
+)
+
+
+# ---------------------------------------------------------------------------
+# Scraper class
+# ---------------------------------------------------------------------------
+
+
+class MayoClinicScraper(BaseScraper):
+    """Scraper for www.mayoclinic.org medical content pages.
+
+    Uses the ten XML sitemaps declared in ``sitemap_urls`` to discover
+    article URLs (6 English + 4 Spanish, as listed in Mayo Clinic's robots.txt). The crawler fetches those URLs and passes the raw HTML
+    to ``scrape()``, which extracts the article using AEM component
+    selectors specific to the Mayo Clinic site.
+
+    Language detection:
+        Read from ``<html lang="...">`` attribute, present on every page.
+        English pages have ``lang="en"``; Spanish pages have ``lang="es"``.
+        The ``spanish_*`` sitemaps contain Spanish URLs, but we derive the
+        language from the tag rather than the sitemap filename for robustness.
+
+    Category detection:
+        Inferred from the URL path:
+            /diseases-conditions/ → "disease"
+            /symptoms/            → "symptom"
+            /tests-procedures/    → "procedure"
+            /drugs-supplements/   → "drug"
+            /healthy-lifestyle/   → "wellness"
+
+    Skip conditions:
+        Returns None (page skipped) when:
+            - No ``<h1>`` is found inside ``#main-content``
+            - Extracted text is fewer than 50 characters
+    """
+
+    domain = "www.mayoclinic.org"
+    source_name = "mayo_clinic"
+    sitemap_urls = [
+        # English — sourced from robots.txt
+        "https://www.mayoclinic.org/condition_consolidated_concepts.xml",
+        "https://www.mayoclinic.org/symptoms_all.xml",
+        "https://www.mayoclinic.org/patient_consumer_web.xml",
+        "https://www.mayoclinic.org/patient_consumer_faq.xml",
+        "https://www.mayoclinic.org/patient_consumer_drug.xml",
+        "https://www.mayoclinic.org/procedure_concepts.xml",
+        # Spanish — sourced from robots.txt
+        "https://www.mayoclinic.org/spanish_condition_consolidated_concepts.xml",
+        "https://www.mayoclinic.org/spanish_patient_consumer_web.xml",
+        "https://www.mayoclinic.org/spanish_patient_consumer_faq.xml",
+        "https://www.mayoclinic.org/spanish_procedure_concepts.xml",
+    ]
+
+    def can_handle(self, url: str) -> bool:
+        """Accept only URLs under known medical content paths.
+
+        Rejects appointments, careers, about-mayo-clinic, and other
+        non-clinical sections before any HTTP request is made.
+
+        Args:
+            url: Absolute URL to evaluate.
+
+        Returns:
+            True if the URL path starts with a known content prefix.
+        """
+        path = urlparse(url).path
+        return any(path.startswith(prefix) for prefix in _CONTENT_PATHS)
+
+    def scrape(self, url: str, html: str) -> Document | None:
+        """Extract a medical Document from a Mayo Clinic article page.
+
+        Args:
+            url: Canonical URL of the page (already fetched by the crawler).
+            html: Raw HTML content as a string.
+
+        Returns:
+            Document with title, content text, and required metadata keys,
+            or None if the page has no extractable medical content.
+        """
+        soup = BeautifulSoup(html, "lxml")
+
+        language = _extract_language(soup)
+        title = _extract_title(soup)
+
+        if not title:
+            logger.debug("No title found — skipping %s", url)
+            return None
+
+        content = _extract_content(soup)
+
+        if len(content) < _MIN_CONTENT_LENGTH:
+            logger.debug(
+                "Content too short (%d chars) — skipping %s", len(content), url
+            )
+            return None
+
+        return Document(
+            doc_id="",  # overwritten by GenericCrawler with UUID5
+            text=content,
+            url=url,
+            metadata={
+                "title": title,
+                "source": self.source_name,
+                "language": language,
+                "date": _extract_date(soup),
+                "category": _infer_category(url),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Private extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_language(soup: BeautifulSoup) -> str:
+    """Read the ISO 639-1 language code from the <html> tag.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Two-letter language code (e.g. "en", "es"). Defaults to "en".
+    """
+    html_tag = soup.find("html")
+    if html_tag:
+        lang = html_tag.get("lang", "en")
+        # Normalize "en-US", "es-MX", etc. → "en", "es"
+        return str(lang).split("-")[0].lower()
+    return "en"
+
+
+def _extract_title(soup: BeautifulSoup) -> str | None:
+    """Extract the article title from the single <h1> on the page.
+
+    Searches inside ``#main-content`` first. If not found there (Mayo Clinic's
+    AEM layout places the ``<h1>`` outside the main content container), falls
+    back to the first ``<h1>`` anywhere on the page.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Title string, or None if no <h1> is found.
+    """
+    main = soup.find(id="main-content")
+    container = main if main else soup
+    h1 = container.find("h1")
+    if not h1 and main:
+        # Mayo Clinic's AEM layout places <h1> outside #main-content
+        h1 = soup.find("h1")
+    if not h1:
+        return None
+    title = h1.get_text(strip=True)
+    return title if title else None
+
+
+def _extract_content(soup: BeautifulSoup) -> str:
+    """Extract body text from <p> tags inside #main-content.
+
+    Skips empty paragraphs and joins non-empty ones with double newlines
+    so that paragraph boundaries are preserved for the indexer.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Concatenated article text, or "" if no content is found.
+    """
+    main = soup.find(id="main-content")
+    if not main:
+        return ""
+
+    paragraphs = [
+        p.get_text(strip=True)
+        for p in main.find_all("p")
+        if p.get_text(strip=True)
+    ]
+    return "\n\n".join(paragraphs)
+
+
+def _extract_date(soup: BeautifulSoup) -> str:
+    """Extract the article date from meta tags.
+
+    Tries ``article:modified_time``, ``article:published_time``, and
+    ``og:updated_time`` in that order. Returns the first non-empty value.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Date string (ISO 8601 format if the site provides it), or "".
+    """
+    for attrs in _DATE_META_ATTRS:
+        tag = soup.find("meta", attrs=attrs)
+        if tag:
+            value = tag.get("content", "").strip()
+            if value:
+                return value
+    return ""
+
+
+def _infer_category(url: str) -> str:
+    """Infer a topic category from the URL path.
+
+    Args:
+        url: Absolute page URL.
+
+    Returns:
+        Category string from ``_CATEGORY_MAP``, or "" if path is unknown.
+    """
+    path = urlparse(url).path
+    for segment, category in _CATEGORY_MAP.items():
+        if segment in path:
+            return category
+    return ""

--- a/modules/crawler/scrapers/medlineplus.py
+++ b/modules/crawler/scrapers/medlineplus.py
@@ -1,0 +1,280 @@
+"""MedlinePlus scraper for medical content acquisition.
+
+MedlinePlus (medlineplus.gov) is a U.S. National Library of Medicine service
+providing authoritative health information for patients and consumers.
+
+Page types handled:
+    - Health topic pages  (e.g., /diabetes.html)           → category "health-topic"
+    - Spanish health topics (e.g., /spanish/diabetes.html) → category "health-topic", language "es"
+    - Medical encyclopedia  (e.g., /ency/article/000305)   → category "reference"
+
+Content structure (confirmed from live HTML):
+    - Title:   <article> → <h1 class="with-also">
+    - Summary: <section id="topsum_section"> → all <p> tags (the actual medical summary)
+    - Date:    <meta name="DC.Date.Modified" content="YYYY-MM-DD">
+    - Language: <html lang="..."> attribute
+
+Sitemap:
+    Single urlset at https://medlineplus.gov/sitemap.xml (~1000+ URLs).
+    The sitemap mixes medical content with index/utility pages; can_handle()
+    filters to content-only URLs before any fetch occurs.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from core.models import Document
+from modules.crawler.base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# Minimum character count for extracted content to be considered valid.
+_MIN_CONTENT_LENGTH: int = 50
+
+
+# ---------------------------------------------------------------------------
+# Scraper class
+# ---------------------------------------------------------------------------
+
+
+class MedlinePlusScraper(BaseScraper):
+    """Scraper for medlineplus.gov health topic and encyclopedia pages.
+
+    URL filtering:
+        - Root-level ``/[topic].html`` pages (English health topics)
+        - ``/spanish/[topic].html`` pages (Spanish health topics)
+        - ``/ency/article/...`` pages (medical encyclopedia)
+        - All other paths are rejected by can_handle().
+
+    Content extraction:
+        Title comes from the ``<h1>`` inside the ``<article>`` tag.
+        Body text comes exclusively from ``<section id="topsum_section">``,
+        which contains the authoritative medical summary paragraphs.
+        The other sections on the page are curated link lists, not prose.
+
+    Language:
+        Read from the ``<html lang="...">`` attribute. Spanish topic pages
+        at ``/spanish/`` also have ``lang="es"`` set by MedlinePlus.
+
+    Date:
+        Read from ``<meta name="DC.Date.Modified" content="YYYY-MM-DD">``,
+        which MedlinePlus consistently provides on all content pages.
+    """
+
+    domain = "medlineplus.gov"
+    source_name = "medlineplus"
+    sitemap_urls = [
+        "https://medlineplus.gov/sitemap.xml",
+    ]
+
+    def can_handle(self, url: str) -> bool:
+        """Accept only medical content URLs from MedlinePlus.
+
+        Accepted patterns:
+            /[topic].html               — root-level English health topics
+            /spanish/[topic].html       — Spanish health topics
+            /ency/article/[id]          — medical encyclopedia articles
+
+        Rejected patterns (index pages, utilities, feeds, organizations):
+            /organizations/...
+            /druginfo/...
+            /all_*.html
+            /connect/
+            /*/feeds/
+            etc.
+
+        Args:
+            url: Absolute URL to evaluate.
+
+        Returns:
+            True if the URL points to a medical content page.
+        """
+        path = urlparse(url).path
+
+        # Root-level health topics: /diabetes.html, /heartdisease.html, etc.
+        # These have exactly one slash and end in .html.
+        if path.endswith(".html") and path.count("/") == 1:
+            return True
+
+        # Spanish health topics: /spanish/diabetes.html
+        if path.startswith("/spanish/") and path.endswith(".html"):
+            return True
+
+        # Medical encyclopedia articles: /ency/article/000305.htm
+        if path.startswith("/ency/article/"):
+            return True
+
+        return False
+
+    def scrape(self, url: str, html: str) -> Document | None:
+        """Extract a medical Document from a MedlinePlus page.
+
+        Args:
+            url: Canonical URL of the page (already fetched by the crawler).
+            html: Raw HTML content as a string.
+
+        Returns:
+            Document with title, summary text, and required metadata keys,
+            or None if the page has no extractable medical content.
+        """
+        soup = BeautifulSoup(html, "lxml")
+
+        language = _extract_language(soup)
+        title = _extract_title(soup)
+
+        if not title:
+            logger.debug("No title found — skipping %s", url)
+            return None
+
+        content = _extract_content(soup)
+
+        if len(content) < _MIN_CONTENT_LENGTH:
+            logger.debug(
+                "Content too short (%d chars) — skipping %s", len(content), url
+            )
+            return None
+
+        return Document(
+            doc_id="",  # overwritten by GenericCrawler with UUID5
+            text=content,
+            url=url,
+            metadata={
+                "title": title,
+                "source": self.source_name,
+                "language": language,
+                "date": _extract_date(soup),
+                "category": _infer_category(url),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Private extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_language(soup: BeautifulSoup) -> str:
+    """Read the ISO 639-1 language code from the <html> tag.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Two-letter language code ("en" or "es"). Defaults to "en".
+    """
+    html_tag = soup.find("html")
+    if html_tag:
+        lang = html_tag.get("lang", "en")
+        return str(lang).split("-")[0].lower()
+    return "en"
+
+
+def _extract_title(soup: BeautifulSoup) -> str | None:
+    """Extract the article title from <h1> inside <article>.
+
+    Falls back to the first <h1> on the page if <article> is absent.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Title string, or None if no <h1> is found.
+    """
+    article = soup.find("article")
+    container = article if article else soup
+    h1 = container.find("h1")
+    if not h1:
+        h1 = soup.find("h1")
+    if not h1:
+        return None
+    title = h1.get_text(strip=True)
+    return title if title else None
+
+
+def _extract_content(soup: BeautifulSoup) -> str:
+    """Extract the medical summary from <section id="topsum_section">.
+
+    MedlinePlus health topic pages have a dedicated summary section with
+    authoritative medical paragraphs. The other sections on the page are
+    curated link lists (not prose), so they are intentionally excluded.
+
+    Falls back to all <p> tags inside <article> if the summary section
+    is absent (e.g., encyclopedia pages use a different layout).
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Concatenated summary text, or "" if no content is found.
+    """
+    # Primary: health topic summary section
+    topsum = soup.find("section", id="topsum_section")
+    if topsum:
+        paragraphs = [
+            p.get_text(strip=True)
+            for p in topsum.find_all("p")
+            if p.get_text(strip=True)
+        ]
+        if paragraphs:
+            return "\n\n".join(paragraphs)
+
+    # Fallback: all paragraphs inside <article> (encyclopedia pages)
+    article = soup.find("article")
+    if article:
+        paragraphs = [
+            p.get_text(strip=True)
+            for p in article.find_all("p")
+            if p.get_text(strip=True)
+        ]
+        return "\n\n".join(paragraphs)
+
+    return ""
+
+
+def _extract_date(soup: BeautifulSoup) -> str:
+    """Extract the last-modified date from Dublin Core meta tags.
+
+    MedlinePlus consistently sets <meta name="DC.Date.Modified"> on all
+    content pages in YYYY-MM-DD format.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Date string (YYYY-MM-DD), or "" if not found.
+    """
+    tag = soup.find("meta", attrs={"name": "DC.Date.Modified"})
+    if tag:
+        value = tag.get("content", "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _infer_category(url: str) -> str:
+    """Infer a topic category from the URL path.
+
+    Args:
+        url: Absolute page URL.
+
+    Returns:
+        Category string: "health-topic", "reference", or "".
+    """
+    path = urlparse(url).path
+
+    if path.startswith("/ency/article/"):
+        return "reference"
+
+    # Root-level and /spanish/ pages are health topic summaries
+    if path.endswith(".html"):
+        return "health-topic"
+
+    return ""

--- a/modules/crawler/scrapers/nhs.py
+++ b/modules/crawler/scrapers/nhs.py
@@ -1,0 +1,263 @@
+"""NHS (National Health Service) scraper for medical content acquisition.
+
+NHS (nhs.uk) is the UK's National Health Service, providing authoritative
+health information for patients and the public.
+
+Page types handled:
+    - Conditions  (e.g., /conditions/diabetes/)       → category "disease"
+    - Medicines   (e.g., /medicines/metformin/)        → category "drug"
+    - Live Well   (e.g., /live-well/eat-well/)         → category "wellness"
+    - Mental health (e.g., /mental-health/conditions/) → category "mental-health"
+
+Content structure (confirmed from live HTML):
+    - Title:    <main id="maincontent"> → <h1>
+    - Content:  all <p> tags inside <main>
+    - Date:     <meta name="article:modified_time" content="...">
+    - Language: <html lang="..."> attribute
+
+Sitemap:
+    Single sitemap index at https://www.nhs.uk/sitemap.xml.
+    can_handle() filters to known medical content paths before any fetch occurs.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
+
+from core.models import Document
+from modules.crawler.base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# Maps URL path segment → category label stored in metadata.
+_CATEGORY_MAP: dict[str, str] = {
+    "conditions": "disease",
+    "medicines": "drug",
+    "live-well": "wellness",
+    "mental-health": "mental-health",
+}
+
+# URL path prefixes that contain actual medical content.
+# Any URL NOT starting with one of these is rejected by can_handle().
+_CONTENT_PATHS: tuple[str, ...] = (
+    "/conditions/",
+    "/medicines/",
+    "/live-well/",
+    "/mental-health/",
+)
+
+# Minimum character count for the extracted text to be considered valid.
+_MIN_CONTENT_LENGTH: int = 50
+
+# Meta tag names/properties to try when looking for the article date,
+# checked in order — first match wins.
+_DATE_META_ATTRS: tuple[dict[str, str], ...] = (
+    {"name": "article:modified_time"},
+    {"property": "article:modified_time"},
+    {"name": "article:published_time"},
+    {"property": "article:published_time"},
+)
+
+
+# ---------------------------------------------------------------------------
+# Scraper class
+# ---------------------------------------------------------------------------
+
+
+class NHSScraper(BaseScraper):
+    """Scraper for www.nhs.uk medical content pages.
+
+    Uses the sitemap at ``sitemap_urls`` to discover article URLs.
+    The crawler fetches those URLs and passes the raw HTML to ``scrape()``,
+    which extracts the article using the NHS page structure.
+
+    Language detection:
+        Read from ``<html lang="...">`` attribute. NHS pages are in English
+        (``lang="en"``).
+
+    Category detection:
+        Inferred from the URL path:
+            /conditions/    → "disease"
+            /medicines/     → "drug"
+            /live-well/     → "wellness"
+            /mental-health/ → "mental-health"
+
+    Skip conditions:
+        Returns None (page skipped) when:
+            - No ``<h1>`` is found inside ``<main>``
+            - Extracted text is fewer than 50 characters
+    """
+
+    domain = "www.nhs.uk"
+    source_name = "nhs"
+    sitemap_urls = [
+        "https://www.nhs.uk/sitemap.xml",
+    ]
+
+    def can_handle(self, url: str) -> bool:
+        """Accept only URLs under known medical content paths.
+
+        Rejects service-search, contact, campaign, and other non-clinical
+        sections before any HTTP request is made.
+
+        Args:
+            url: Absolute URL to evaluate.
+
+        Returns:
+            True if the URL path starts with a known content prefix.
+        """
+        path = urlparse(url).path
+        return any(path.startswith(prefix) for prefix in _CONTENT_PATHS)
+
+    def scrape(self, url: str, html: str) -> Document | None:
+        """Extract a medical Document from an NHS page.
+
+        Args:
+            url: Canonical URL of the page (already fetched by the crawler).
+            html: Raw HTML content as a string.
+
+        Returns:
+            Document with title, content text, and required metadata keys,
+            or None if the page has no extractable medical content.
+        """
+        soup = BeautifulSoup(html, "lxml")
+
+        language = _extract_language(soup)
+        title = _extract_title(soup)
+
+        if not title:
+            logger.debug("No title found — skipping %s", url)
+            return None
+
+        content = _extract_content(soup)
+
+        if len(content) < _MIN_CONTENT_LENGTH:
+            logger.debug(
+                "Content too short (%d chars) — skipping %s", len(content), url
+            )
+            return None
+
+        return Document(
+            doc_id="",  # overwritten by GenericCrawler with UUID5
+            text=content,
+            url=url,
+            metadata={
+                "title": title,
+                "source": self.source_name,
+                "language": language,
+                "date": _extract_date(soup),
+                "category": _infer_category(url),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Private extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_language(soup: BeautifulSoup) -> str:
+    """Read the ISO 639-1 language code from the <html> tag.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Two-letter language code (e.g. "en"). Defaults to "en".
+    """
+    html_tag = soup.find("html")
+    if html_tag:
+        lang = html_tag.get("lang", "en")
+        return str(lang).split("-")[0].lower()
+    return "en"
+
+
+def _extract_title(soup: BeautifulSoup) -> str | None:
+    """Extract the article title from the <h1> inside <main>.
+
+    Falls back to the first <h1> anywhere on the page if <main> is absent.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Title string, or None if no <h1> is found.
+    """
+    main = soup.find("main")
+    container = main if main else soup
+    h1 = container.find("h1")
+    if not h1:
+        h1 = soup.find("h1")
+    if not h1:
+        return None
+    title = h1.get_text(strip=True)
+    return title if title else None
+
+
+def _extract_content(soup: BeautifulSoup) -> str:
+    """Extract body text from <p> tags inside <main>.
+
+    Skips empty paragraphs and joins non-empty ones with double newlines
+    so that paragraph boundaries are preserved for the indexer.
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Concatenated article text, or "" if no content is found.
+    """
+    main = soup.find("main")
+    if not main:
+        return ""
+
+    paragraphs = [
+        p.get_text(strip=True)
+        for p in main.find_all("p")
+        if p.get_text(strip=True)
+    ]
+    return "\n\n".join(paragraphs)
+
+
+def _extract_date(soup: BeautifulSoup) -> str:
+    """Extract the article date from meta tags.
+
+    Tries ``article:modified_time`` and ``article:published_time`` in that
+    order. Returns the first non-empty value as-is (NHS uses a human-readable
+    format, e.g. "3 Jul 2025, 11:31 a.m.").
+
+    Args:
+        soup: Parsed page.
+
+    Returns:
+        Date string as provided by the site, or "" if not found.
+    """
+    for attrs in _DATE_META_ATTRS:
+        tag = soup.find("meta", attrs=attrs)
+        if tag:
+            value = tag.get("content", "").strip()
+            if value:
+                return value
+    return ""
+
+
+def _infer_category(url: str) -> str:
+    """Infer a topic category from the URL path.
+
+    Args:
+        url: Absolute page URL.
+
+    Returns:
+        Category string from ``_CATEGORY_MAP``, or "" if path is unknown.
+    """
+    path = urlparse(url).path
+    for segment, category in _CATEGORY_MAP.items():
+        if f"/{segment}/" in path:
+            return category
+    return ""

--- a/modules/crawler/service.py
+++ b/modules/crawler/service.py
@@ -1,0 +1,91 @@
+"""CrawlerService — single entry point for initiating a crawl session.
+
+Application code (CLI, tests, pipeline) should instantiate CrawlerService
+rather than GenericCrawler directly. This facade assembles the three
+collaborating objects (GenericCrawler, RawDocumentStorage, CrawlConfig) so
+callers do not need to know about the internal wiring.
+
+Usage:
+    from modules.crawler import CrawlerService, CrawlConfig
+    from modules.crawler.scrapers.mayo_clinic import MayoClinicScraper
+
+    service = CrawlerService(
+        scrapers=[MayoClinicScraper()],
+        config=CrawlConfig(max_pages=500),
+    )
+    result = service.run()
+    print(result)
+"""
+
+from __future__ import annotations
+
+import logging
+
+from infra.storage import RawDocumentStorage
+from modules.crawler.base import BaseScraper
+from modules.crawler.crawler import GenericCrawler
+from modules.crawler.models import CrawlConfig, CrawlResult
+
+logger = logging.getLogger(__name__)
+
+
+class CrawlerService:
+    """Facade that assembles and runs a crawl session.
+
+    Combines GenericCrawler, RawDocumentStorage, and CrawlConfig into a
+    single cohesive object. Callers provide scrapers and an optional config;
+    the service handles the rest.
+
+    Attributes:
+        _scrapers: List of site-specific scraper instances to use.
+        _config: Crawl configuration (delays, limits, output dir, etc.).
+        _storage: Storage backend writing to config.output_dir.
+
+    Example:
+        service = CrawlerService(
+            scrapers=[MayoClinicScraper(), MedlinePlusScraper()],
+            config=CrawlConfig(delay_seconds=1.5, max_pages=1000),
+        )
+        result = service.run()
+        print(f"Saved {result.documents_saved} documents in {result.duration_seconds:.1f}s")
+    """
+
+    def __init__(
+        self,
+        scrapers: list[BaseScraper],
+        config: CrawlConfig | None = None,
+    ) -> None:
+        """Initialize the crawler service.
+
+        Args:
+            scrapers: Instantiated scraper objects. Must be non-empty.
+            config: Crawl configuration. Uses CrawlConfig defaults if None.
+
+        Raises:
+            ValueError: If scrapers list is empty.
+        """
+        if not scrapers:
+            raise ValueError("At least one scraper must be provided.")
+
+        self._scrapers = scrapers
+        self._config = config or CrawlConfig()
+        self._storage = RawDocumentStorage(self._config.output_dir)
+
+    def run(self) -> CrawlResult:
+        """Assemble the crawler and execute the crawl session.
+
+        Returns:
+            CrawlResult with statistics for the completed session.
+        """
+        logger.info(
+            "Starting crawl session: %d scraper(s), max_pages=%s, delay=%.1fs",
+            len(self._scrapers),
+            self._config.max_pages,
+            self._config.delay_seconds,
+        )
+        crawler = GenericCrawler(
+            scrapers=self._scrapers,
+            config=self._config,
+            storage=self._storage,
+        )
+        return crawler.crawl()

--- a/modules/indexer/document_store.py
+++ b/modules/indexer/document_store.py
@@ -4,20 +4,10 @@ Stores full document content as JSON files on disk, indexed by document ID.
 This provides fast, simple document retrieval decoupled from vector search.
 """
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 import hashlib
 import json
 import logging
 import re
-<<<<<<< HEAD
-=======
-import json
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 from pathlib import Path
 from typing import Optional
 
@@ -25,10 +15,6 @@ from core.interfaces import DocumentStore
 from core.models import Document
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 logger = logging.getLogger(__name__)
 
 # Maximum length for a safe filename (conservative for cross-platform compatibility)
@@ -56,7 +42,6 @@ class DocumentReadError(DocumentStoreError):
     pass
 
 
-<<<<<<< HEAD
 class FileSystemDocumentStore(DocumentStore):
     """Stores documents as individual JSON files on the filesystem.
 
@@ -64,30 +49,11 @@ class FileSystemDocumentStore(DocumentStore):
     Document IDs are sanitized to prevent path traversal and ensure cross-platform
     compatibility. IDs with special characters or excessive length are hashed.
 
-=======
-class FileSystemDocumentStore(DocumentStore):
-    """Stores documents as individual JSON files on the filesystem.
-
-    Each document is saved as {doc_id}.json in the storage directory.
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-class FileSystemDocumentStore(DocumentStore):
-    """Stores documents as individual JSON files on the filesystem.
-
-    Each document is saved as {safe_doc_id}.json in the storage directory.
-    Document IDs are sanitized to prevent path traversal and ensure cross-platform
-    compatibility. IDs with special characters or excessive length are hashed.
-
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
     This provides:
         - Simple persistence without external dependencies
         - Fast random access by document ID
         - Easy inspection and debugging
         - Efficient for small to medium corpora (<100K documents)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
         - Security against path traversal attacks
 
     For production scale (>100K documents), consider migrating to SQLite or PostgreSQL.
@@ -95,13 +61,6 @@ class FileSystemDocumentStore(DocumentStore):
     Raises:
         DocumentWriteError: When a document cannot be saved to disk.
         DocumentReadError: When a document cannot be read from disk.
-<<<<<<< HEAD
-=======
-
-    For production scale (>100K documents), consider migrating to SQLite or PostgreSQL.
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
     """
 
     def __init__(self, storage_dir: str = "data/documents") -> None:
@@ -109,18 +68,9 @@ class FileSystemDocumentStore(DocumentStore):
 
         Args:
             storage_dir: Directory path where document JSON files will be stored.
-<<<<<<< HEAD
-<<<<<<< HEAD
 
         Raises:
             OSError: If the directory cannot be created.
-=======
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-
-        Raises:
-            OSError: If the directory cannot be created.
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
         """
         self.storage_dir = Path(storage_dir)
         self.storage_dir.mkdir(parents=True, exist_ok=True)
@@ -128,8 +78,6 @@ class FileSystemDocumentStore(DocumentStore):
     def add_documents(self, documents: list[Document]) -> None:
         """Store documents to disk as JSON files.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
         Each document is serialized to JSON and saved with a sanitized filename
         based on its doc_id. Existing documents with the same ID are overwritten.
 
@@ -165,48 +113,6 @@ class FileSystemDocumentStore(DocumentStore):
                 raise DocumentWriteError(
                     f"Cannot save document '{doc.doc_id}': {e}"
                 ) from e
-=======
-=======
-        Each document is serialized to JSON and saved with a sanitized filename
-        based on its doc_id. Existing documents with the same ID are overwritten.
-
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
-        Args:
-            documents: List of documents to persist.
-
-        Raises:
-            DocumentWriteError: If any document fails to save. The error message
-                includes the doc_id and underlying cause.
-        """
-        for doc in documents:
-            doc_path = self._get_document_path(doc.doc_id)
-            try:
-                data = {
-                    "doc_id": doc.doc_id,
-                    "text": doc.text,
-                    "url": doc.url,
-                    "metadata": doc.metadata,
-                }
-                with open(doc_path, "w", encoding="utf-8") as f:
-                    json.dump(data, f, ensure_ascii=False, indent=2)
-            except TypeError as e:
-                # Non-serializable data in metadata
-                logger.error(
-                    f"Document {doc.doc_id} contains non-serializable data: {e}"
-                )
-<<<<<<< HEAD
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-                raise DocumentWriteError(
-                    f"Cannot serialize document '{doc.doc_id}': {e}"
-                ) from e
-            except OSError as e:
-                # Disk full, permission denied, etc.
-                logger.error(f"Failed to write document {doc.doc_id}: {e}")
-                raise DocumentWriteError(
-                    f"Cannot save document '{doc.doc_id}': {e}"
-                ) from e
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 
     def get_by_id(self, doc_id: str) -> Optional[Document]:
         """Retrieve a single document by its ID.
@@ -216,27 +122,14 @@ class FileSystemDocumentStore(DocumentStore):
 
         Returns:
             Document if found, None if the file doesn't exist.
-<<<<<<< HEAD
-<<<<<<< HEAD
 
         Raises:
             DocumentReadError: If the file exists but cannot be read or parsed.
-=======
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-
-        Raises:
-            DocumentReadError: If the file exists but cannot be read or parsed.
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
         """
         doc_path = self._get_document_path(doc_id)
         if not doc_path.exists():
             return None
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
         try:
             with open(doc_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
@@ -261,49 +154,22 @@ class FileSystemDocumentStore(DocumentStore):
             raise DocumentReadError(
                 f"Cannot read document '{doc_id}': {e}"
             ) from e
-<<<<<<< HEAD
-=======
-        with open(doc_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-            return Document(
-                doc_id=data["doc_id"],
-                text=data["text"],
-                url=data["url"],
-                metadata=data.get("metadata", {}),
-            )
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 
     def get_by_ids(self, doc_ids: list[str]) -> list[Document]:
         """Batch retrieve multiple documents by their IDs.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
         Documents are returned in the same order as the input IDs.
         Missing documents are skipped silently (logged at debug level).
 
-=======
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-        Documents are returned in the same order as the input IDs.
-        Missing documents are skipped silently (logged at debug level).
-
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
         Args:
             doc_ids: List of document IDs to fetch.
 
         Returns:
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
             List of found documents. Missing IDs are skipped.
 
         Note:
             Read errors for individual documents are logged but don't stop
             the batch operation. Only successfully read documents are returned.
-<<<<<<< HEAD
         """
         documents = []
         for doc_id in doc_ids:
@@ -388,98 +254,4 @@ class FileSystemDocumentStore(DocumentStore):
             safe_id = hash_digest[:32]  # 32 chars is plenty for uniqueness
             logger.debug(f"Hashed doc_id '{doc_id[:50]}...' -> {safe_id}")
 
-=======
-            List of found documents (missing IDs are skipped silently).
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
-        """
-        documents = []
-        for doc_id in doc_ids:
-            try:
-                doc = self.get_by_id(doc_id)
-                if doc is not None:
-                    documents.append(doc)
-                else:
-                    logger.debug(f"Document not found: {doc_id}")
-            except DocumentReadError as e:
-                # Log but continue with other documents
-                logger.warning(f"Skipping unreadable document {doc_id}: {e}")
-        return documents
-
-    def exists(self, doc_id: str) -> bool:
-        """Check if a document exists without loading it.
-
-        Args:
-            doc_id: Document identifier.
-
-        Returns:
-            True if the document file exists, False otherwise.
-        """
-<<<<<<< HEAD
-        # Sanitize doc_id to prevent path traversal attacks
-        safe_id = doc_id.replace("/", "_").replace("\\", "_")
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-        return self._get_document_path(doc_id).exists()
-
-    def delete(self, doc_id: str) -> bool:
-        """Delete a document from storage.
-
-        Args:
-            doc_id: Document identifier.
-
-        Returns:
-            True if the document was deleted, False if it didn't exist.
-
-        Raises:
-            DocumentStoreError: If the file exists but cannot be deleted.
-        """
-        doc_path = self._get_document_path(doc_id)
-        if not doc_path.exists():
-            return False
-
-        try:
-            doc_path.unlink()
-            return True
-        except OSError as e:
-            logger.error(f"Failed to delete document {doc_id}: {e}")
-            raise DocumentStoreError(
-                f"Cannot delete document '{doc_id}': {e}"
-            ) from e
-
-    def _get_document_path(self, doc_id: str) -> Path:
-        """Compute a safe filesystem path for a document ID.
-
-        Sanitizes the doc_id to prevent:
-            - Path traversal attacks (../, etc.)
-            - Invalid filename characters on Windows (:, *, ?, etc.)
-            - Excessively long filenames
-            - Hidden files (starting with .)
-
-        If the doc_id contains problematic characters or is too long,
-        it's replaced with a SHA-256 hash prefix for safe storage.
-
-        Args:
-            doc_id: Document identifier (may contain any characters).
-
-        Returns:
-            Path object pointing to a safe JSON filename.
-        """
-        # Check if doc_id is safe to use directly as filename
-        is_safe = (
-            SAFE_FILENAME_PATTERN.match(doc_id)
-            and len(doc_id) <= MAX_FILENAME_LENGTH
-            and not doc_id.startswith(".")
-            and doc_id not in (".", "..")
-        )
-
-        if is_safe:
-            safe_id = doc_id
-        else:
-            # Use hash for problematic IDs
-            hash_digest = hashlib.sha256(doc_id.encode("utf-8")).hexdigest()
-            safe_id = hash_digest[:32]  # 32 chars is plenty for uniqueness
-            logger.debug(f"Hashed doc_id '{doc_id[:50]}...' -> {safe_id}")
-
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
         return self.storage_dir / f"{safe_id}.json"

--- a/modules/indexer/service.py
+++ b/modules/indexer/service.py
@@ -61,12 +61,6 @@ class IndexerService:
     def build(self, documents: list[Document]) -> IndexedCorpus:
         """Build an IndexedCorpus from raw documents.
 
-        Steps:
-            1. Preprocess each document using TextProcessor (is_query=False).
-            2. Build inverted index: term → [(doc_index, term_frequency), ...]
-            3. Create sorted vocabulary list of unique terms.
-            4. Return IndexedCorpus with all fields.
-
         Args:
             documents: List of documents to index.
 
@@ -74,59 +68,9 @@ class IndexerService:
             IndexedCorpus with inverted_index and vocabulary.
 
         Raises:
-            ValueError: If documents list is empty.
+            NotImplementedError: This is a stub. Implement as needed.
         """
-        if not documents:
-            raise ValueError("Cannot index empty document list.")
-
-        processed_texts: list[str] = []
-        inverted_index: dict[str, list[tuple[int, int]]] = {}
-
-        # Step 1: Preprocess all documents
-        for doc_idx, doc in enumerate(documents):
-            if doc_idx % self.config.log_progress_every == 0:
-                print(f"Indexing document {doc_idx + 1}/{len(documents)}...")
-
-            # Preprocess the document using TextProcessor (is_query=False)
-            processed = self.text_processor.process(doc.text, is_query=False)
-
-            # Validate minimum document length
-            token_count = len(processed.split())
-            if token_count < self.config.min_document_length:
-                print(f"  Warning: Document '{doc.doc_id}' has {token_count} tokens, "
-                      f"below minimum {self.config.min_document_length}. Skipping.")
-                continue
-
-            processed_texts.append(processed)
-
-            # Step 2: Build inverted index from token frequencies
-            # Count token occurrences in this document
-            token_freq: dict[str, int] = {}
-            for token in processed.split():
-                token_freq[token] = token_freq.get(token, 0) + 1
-
-            # Add to inverted index
-            for token, freq in token_freq.items():
-                if token not in inverted_index:
-                    inverted_index[token] = []
-                inverted_index[token].append((doc_idx, freq))
-
-        # Step 3: Extract and sort vocabulary
-        # Filter by minimum term frequency
-        vocabulary = sorted([
-            term for term, postings in inverted_index.items()
-            if len(postings) >= self.config.min_term_frequency
-        ])
-
-        # Re-filter inverted index to match vocabulary
-        filtered_inverted_index = {
-            term: inverted_index[term]
-            for term in vocabulary
-        }
-
-        return IndexedCorpus(
-            documents=documents,
-            processed_texts=processed_texts,
-            inverted_index=filtered_inverted_index,
-            vocabulary=vocabulary,
+        raise NotImplementedError(
+            "IndexerService.build() must be implemented. "
+            "Should return IndexedCorpus with inverted_index and vocabulary."
         )

--- a/modules/indexer/service.py
+++ b/modules/indexer/service.py
@@ -61,6 +61,12 @@ class IndexerService:
     def build(self, documents: list[Document]) -> IndexedCorpus:
         """Build an IndexedCorpus from raw documents.
 
+        Steps:
+            1. Preprocess each document using TextProcessor (is_query=False).
+            2. Build inverted index: term → [(doc_index, term_frequency), ...]
+            3. Create sorted vocabulary list of unique terms.
+            4. Return IndexedCorpus with all fields.
+
         Args:
             documents: List of documents to index.
 
@@ -68,9 +74,59 @@ class IndexerService:
             IndexedCorpus with inverted_index and vocabulary.
 
         Raises:
-            NotImplementedError: This is a stub. Implement as needed.
+            ValueError: If documents list is empty.
         """
-        raise NotImplementedError(
-            "IndexerService.build() must be implemented. "
-            "Should return IndexedCorpus with inverted_index and vocabulary."
+        if not documents:
+            raise ValueError("Cannot index empty document list.")
+
+        processed_texts: list[str] = []
+        inverted_index: dict[str, list[tuple[int, int]]] = {}
+
+        # Step 1: Preprocess all documents
+        for doc_idx, doc in enumerate(documents):
+            if doc_idx % self.config.log_progress_every == 0:
+                print(f"Indexing document {doc_idx + 1}/{len(documents)}...")
+
+            # Preprocess the document using TextProcessor (is_query=False)
+            processed = self.text_processor.process(doc.text, is_query=False)
+
+            # Validate minimum document length
+            token_count = len(processed.split())
+            if token_count < self.config.min_document_length:
+                print(f"  Warning: Document '{doc.doc_id}' has {token_count} tokens, "
+                      f"below minimum {self.config.min_document_length}. Skipping.")
+                continue
+
+            processed_texts.append(processed)
+
+            # Step 2: Build inverted index from token frequencies
+            # Count token occurrences in this document
+            token_freq: dict[str, int] = {}
+            for token in processed.split():
+                token_freq[token] = token_freq.get(token, 0) + 1
+
+            # Add to inverted index
+            for token, freq in token_freq.items():
+                if token not in inverted_index:
+                    inverted_index[token] = []
+                inverted_index[token].append((doc_idx, freq))
+
+        # Step 3: Extract and sort vocabulary
+        # Filter by minimum term frequency
+        vocabulary = sorted([
+            term for term, postings in inverted_index.items()
+            if len(postings) >= self.config.min_term_frequency
+        ])
+
+        # Re-filter inverted index to match vocabulary
+        filtered_inverted_index = {
+            term: inverted_index[term]
+            for term in vocabulary
+        }
+
+        return IndexedCorpus(
+            documents=documents,
+            processed_texts=processed_texts,
+            inverted_index=filtered_inverted_index,
+            vocabulary=vocabulary,
         )

--- a/modules/retriever/service.py
+++ b/modules/retriever/service.py
@@ -4,31 +4,22 @@ This is the main entry-point for retrieval. It implements a two-tier storage arc
     - Vector DB (ChromaDB): Stores doc IDs + embeddings for fast similarity search
     - Document Store: Stores full document text and metadata
 
-Retrieval flow:
-<<<<<<< HEAD
-    IndexedCorpus (docs) → TfidfProcessor.fit() → LSIModel.fit() → store vectors
-    IndexedCorpus (query) → TfidfProcessor.transform() → LSIModel.project() → search
-=======
-    IndexedCorpus → TfidfProcessor → LSIModel → ChromaRepository (vectors)
-                                                → DocumentStore (full text)
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
+Retrieval pipeline:
+    Query (raw text) → TextProcessor.process(is_query=True)
+                    → TfidfProcessor.transform()
+                    → LSIModel.project_query()
+                    → ChromaRepository.search_similar()
+                    → DocumentStore.get_by_ids()
+                    → RetrievedDocument list (ranked)
 """
 
 from __future__ import annotations
 
-<<<<<<< HEAD
-=======
-import re
-
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 from core.interfaces import BaseRetriever, BaseRepository, DocumentStore, IndexedCorpus
 from core.models import Query, RetrievedDocument
+from modules.text_processor import TextProcessor
 
 from .lsi_model import LSIModel
-<<<<<<< HEAD
-=======
-from .spell_checker import TrieSpellChecker
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 from .tfidf_processor import TfidfProcessor
 
 
@@ -36,22 +27,17 @@ class LSIRetriever(BaseRetriever):
     """Retriever based on TF-IDF + TruncatedSVD (LSI) with two-tier storage.
 
     Orchestrates:
-        1. TfidfProcessor    — builds/queries the TF-IDF matrix.
-        2. LSIModel          — reduces dimensionality via SVD.
-        3. BaseRepository    — stores/searches document vectors (ChromaDB).
-        4. DocumentStore     — stores full document text and metadata.
-<<<<<<< HEAD
-=======
-        5. TrieSpellChecker  — corrects query typos before vectorization.
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
+        1. TextProcessor     — normalizes and preprocesses query text.
+        2. TfidfProcessor    — builds/queries the TF-IDF matrix.
+        3. LSIModel          — reduces dimensionality via SVD.
+        4. BaseRepository    — stores/searches document vectors (ChromaDB).
+        5. DocumentStore     — stores full document text and metadata.
 
     Storage architecture:
         - Vector DB: ID + embedding + URL (for fast similarity search)
         - Document Store: ID + full text + metadata (for retrieval)
     """
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     # Default similarity threshold - results below this score are filtered out
     DEFAULT_SIMILARITY_THRESHOLD = 0.4
 
@@ -59,91 +45,9 @@ class LSIRetriever(BaseRetriever):
         self,
         repository: BaseRepository,
         document_store: DocumentStore,
+        text_processor: TextProcessor | None = None,
         model_dir: str = "models/lsi",
         n_components: int = 100,
-        similarity_threshold: float | None = None,
-    ) -> None:
-        """Initialize with repository, document store, and hyper-parameters.
-
-        Args:
-            repository: Vector storage backend (e.g. ChromaRepository).
-            document_store: Full text storage backend (e.g. FileSystemDocumentStore).
-            model_dir: Directory for persisting model artifacts.
-            n_components: Number of latent LSI dimensions.
-            similarity_threshold: Minimum similarity score (0-1) for results.
-                Results below this threshold are filtered out. If None, uses
-                DEFAULT_SIMILARITY_THRESHOLD (0.4).
-        """
-        self.repository = repository
-        self.document_store = document_store
-        self.model_dir = model_dir
-        self.n_components = n_components
-        self.similarity_threshold = (
-            similarity_threshold
-            if similarity_threshold is not None
-            else self.DEFAULT_SIMILARITY_THRESHOLD
-        )
-
-        # Sub-components — initialized during fit or load
-        self.tfidf: TfidfProcessor | None = None
-        self.model: LSIModel | None = None
-
-    # ------------------------------------------------------------------
-    # Training
-    # ------------------------------------------------------------------
-
-    def fit(self, corpus: IndexedCorpus) -> None:
-        """Fit the full retrieval pipeline from an indexed corpus.
-
-        Steps:
-            1. Build TF-IDF matrix from the IndexedCorpus (uses inverted_index).
-            2. Fit LSI (SVD) on the TF-IDF matrix → document vectors.
-            3. Store documents in document store (full text + metadata).
-            4. Store IDs + vectors + URLs in vector repository.
-
-        Args:
-            corpus: Preprocessed corpus from the indexer, containing
-                documents, processed texts, inverted index, and vocabulary.
-        """
-        # 1. TF-IDF - build matrix from inverted index
-        self.tfidf = TfidfProcessor()
-        tfidf_matrix = self.tfidf.fit(corpus)
-
-        # 2. LSI
-        self.model = LSIModel(n_components=self.n_components)
-        embeddings = self.model.fit(tfidf_matrix)
-
-        # 3. Store full documents in document store
-        self.document_store.add_documents(corpus.documents)
-
-        # 4. Store vectors in vector repository (IDs + embeddings + URLs)
-        self.repository.add_documents(corpus.documents, embeddings=embeddings)
-
-    # ------------------------------------------------------------------
-    # Query
-    # ------------------------------------------------------------------
-
-    def retrieve(
-        self,
-        query: Query,
-        top_k: int = 10,
-        threshold: float | None = None,
-    ) -> list[RetrievedDocument]:
-        """Retrieve the top-k most relevant documents for a query.
-
-=======
-=======
-    # Default similarity threshold - results below this score are filtered out
-    DEFAULT_SIMILARITY_THRESHOLD = 0.4
-
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
-    def __init__(
-        self,
-        repository: BaseRepository,
-        document_store: DocumentStore,
-        model_dir: str = "models/lsi",
-        n_components: int = 100,
-        max_spell_distance: int = 2,
         tfidf_max_features: int | None = 10_000,
         tfidf_min_df: int = 1,
         tfidf_max_df: float = 0.95,
@@ -154,22 +58,23 @@ class LSIRetriever(BaseRetriever):
         Args:
             repository: Vector storage backend (e.g. ChromaRepository).
             document_store: Full text storage backend (e.g. FileSystemDocumentStore).
+            text_processor: TextProcessor for query preprocessing. If None, must be
+                set via set_text_processor() before calling retrieve().
             model_dir: Directory for persisting model artifacts.
             n_components: Number of latent LSI dimensions.
-            max_spell_distance: Max edit distance for spelling correction.
             tfidf_max_features: Cap on TF-IDF vocabulary size (ignored when
                 the corpus supplies its own vocabulary).
             tfidf_min_df: Minimum document frequency for TF-IDF terms.
             tfidf_max_df: Maximum document frequency for TF-IDF terms.
             similarity_threshold: Minimum similarity score (0-1) for results.
                 Results below this threshold are filtered out. If None, uses
-                DEFAULT_SIMILARITY_THRESHOLD (0.1).
+                DEFAULT_SIMILARITY_THRESHOLD (0.4).
         """
         self.repository = repository
         self.document_store = document_store
+        self.text_processor = text_processor
         self.model_dir = model_dir
         self.n_components = n_components
-        self.max_spell_distance = max_spell_distance
         self.similarity_threshold = (
             similarity_threshold
             if similarity_threshold is not None
@@ -179,12 +84,19 @@ class LSIRetriever(BaseRetriever):
         # Sub-components — initialized during fit or load
         self.tfidf: TfidfProcessor | None = None
         self.model: LSIModel | None = None
-        self.spell_checker: TrieSpellChecker | None = None
 
         # Store TF-IDF hyperparameters for deferred construction
         self._tfidf_max_features = tfidf_max_features
         self._tfidf_min_df = tfidf_min_df
         self._tfidf_max_df = tfidf_max_df
+
+    def set_text_processor(self, text_processor: TextProcessor) -> None:
+        """Set or override the TextProcessor for query preprocessing.
+
+        Args:
+            text_processor: TextProcessor instance for query preprocessing.
+        """
+        self.text_processor = text_processor
 
     # ------------------------------------------------------------------
     # Training
@@ -194,17 +106,16 @@ class LSIRetriever(BaseRetriever):
         """Fit the full retrieval pipeline from an indexed corpus.
 
         Steps:
-            1. Build TF-IDF matrix from the ``IndexedCorpus``.
+            1. Build TF-IDF matrix from the IndexedCorpus.
             2. Fit LSI (SVD) on the TF-IDF matrix → document vectors.
             3. Store documents in document store (full text + metadata).
             4. Store IDs + vectors + URLs in vector repository.
-            5. Initialize the spell-checker with the TF-IDF vocabulary.
 
         Args:
             corpus: Preprocessed corpus from the indexer, containing
-                documents and their processed texts.
+                documents, processed texts, inverted index, and vocabulary.
         """
-        # 1. TF-IDF
+        # 1. TF-IDF - build matrix from indexed corpus
         self.tfidf = TfidfProcessor(
             max_features=self._tfidf_max_features,
             min_df=self._tfidf_min_df,
@@ -222,13 +133,6 @@ class LSIRetriever(BaseRetriever):
         # 4. Store vectors in vector repository (IDs + embeddings + URLs)
         self.repository.add_documents(corpus.documents, embeddings=embeddings)
 
-        # 5. Spell checker from TF-IDF vocabulary
-        vocab = self.tfidf.vocabulary
-        self.spell_checker = TrieSpellChecker(
-            vocabulary=vocab,
-            max_distance=self.max_spell_distance,
-        )
-
     # ------------------------------------------------------------------
     # Query
     # ------------------------------------------------------------------
@@ -241,22 +145,16 @@ class LSIRetriever(BaseRetriever):
     ) -> list[RetrievedDocument]:
         """Retrieve the top-k most relevant documents for a query.
 
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-        Two-phase retrieval:
-            1. Vector similarity search → returns doc IDs and scores
-            2. Fetch full documents from document store by IDs
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-        Results are filtered by similarity threshold and returned in ranked order
-        (highest score first).
-
-        The query must contain an IndexedCorpus (built by the pipeline).
-        The TF-IDF processor filters terms not in its vocabulary, then
-        projects through LSI for vector search.
+        Pipeline:
+            1. Preprocess query using TextProcessor (normalize, tokenize, lemmatize)
+            2. Transform to TF-IDF vector
+            3. Project to LSI latent space
+            4. Search ChromaDB for similar documents
+            5. Fetch full documents from DocumentStore
+            6. Filter by similarity threshold and return ranked results
 
         Args:
-            query: User query with indexed_corpus populated.
+            query: User query with text string.
             top_k: Maximum number of results to return.
             threshold: Minimum similarity score (0-1) for results. If None,
                 uses the instance's similarity_threshold. Results below this
@@ -268,59 +166,26 @@ class LSIRetriever(BaseRetriever):
 
         Raises:
             RuntimeError: If the retriever has not been fitted or loaded.
-            ValueError: If query.indexed_corpus is None.
-=======
-=======
-        Results are filtered by similarity threshold and returned in ranked order
-        (highest score first).
-
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
-        The query text is cleaned, spell-corrected, projected through
-        TF-IDF → LSI, and used to search the vector repository.
-
-        Args:
-            query: User query.
-            top_k: Maximum number of results to return.
-            threshold: Minimum similarity score (0-1) for results. If None,
-                uses the instance's similarity_threshold. Results below this
-                threshold are filtered out.
-
-        Returns:
-            Ranked list of retrieved documents with full text, filtered by
-            similarity threshold and sorted by score (descending).
-
-        Raises:
-            RuntimeError: If the retriever has not been fitted or loaded.
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
+            RuntimeError: If TextProcessor is not set and needed.
         """
         if self.tfidf is None or self.model is None:
             raise RuntimeError(
                 "Retriever must be fitted or loaded before use."
             )
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        if query.indexed_corpus is None:
-            raise ValueError(
-                "Query must have indexed_corpus populated. "
-                "Build it with the indexer before calling retrieve()."
-            )
-
         # Use provided threshold or fall back to instance default
         min_score = threshold if threshold is not None else self.similarity_threshold
 
-        # Phase 1: Vector similarity search
-        query_tfidf = self.tfidf.transform(query.indexed_corpus)
-=======
-=======
-        # Use provided threshold or fall back to instance default
-        min_score = threshold if threshold is not None else self.similarity_threshold
+        # Phase 1: Preprocess query text
+        if self.text_processor is not None:
+            # Full preprocessing: normalize, tokenize, lemmatize, spell check
+            processed_query = self.text_processor.process(query.text, is_query=True)
+        else:
+            # Fallback: minimal preprocessing (assumes query is already somewhat clean)
+            processed_query = query.text.lower().strip()
 
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
-        # Phase 1: Vector similarity search
-        clean_text = self._normalize_query(query.text)
-        query_tfidf = self.tfidf.transform(clean_text)
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
+        # Phase 2: Vector similarity search
+        query_tfidf = self.tfidf.transform(processed_query)
         query_vector = self.model.project_query(query_tfidf)
 
         # Get ranked (doc_id, score) pairs from vector DB
@@ -329,10 +194,6 @@ class LSIRetriever(BaseRetriever):
         if not results:
             return []
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
         # Filter by similarity threshold
         filtered_results = [
             (doc_id, score) for doc_id, score in results if score >= min_score
@@ -341,8 +202,7 @@ class LSIRetriever(BaseRetriever):
         if not filtered_results:
             return []
 
-<<<<<<< HEAD
-        # Phase 2: Fetch full documents from document store
+        # Phase 3: Fetch full documents from document store
         doc_ids = [doc_id for doc_id, _ in filtered_results]
         score_map = {doc_id: score for doc_id, score in filtered_results}
 
@@ -359,36 +219,6 @@ class LSIRetriever(BaseRetriever):
                         score=score_map[doc_id],
                     )
                 )
-=======
-=======
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
-        # Phase 2: Fetch full documents from document store
-        doc_ids = [doc_id for doc_id, _ in filtered_results]
-        score_map = {doc_id: score for doc_id, score in filtered_results}
-
-        documents = self.document_store.get_by_ids(doc_ids)
-        doc_map = {doc.doc_id: doc for doc in documents}
-
-<<<<<<< HEAD
-        # Combine documents with their scores
-        retrieved = [
-            RetrievedDocument(document=doc, score=score_map[doc.doc_id])
-            for doc in documents
-            if doc.doc_id in score_map
-        ]
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-        # Build result list preserving original ranking order from vector search
-        retrieved = []
-        for doc_id in doc_ids:
-            if doc_id in doc_map:
-                retrieved.append(
-                    RetrievedDocument(
-                        document=doc_map[doc_id],
-                        score=score_map[doc_id],
-                    )
-                )
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 
         return retrieved
 
@@ -413,79 +243,32 @@ class LSIRetriever(BaseRetriever):
         cls,
         repository: BaseRepository,
         document_store: DocumentStore,
+        text_processor: TextProcessor | None = None,
         model_dir: str = "models/lsi",
-<<<<<<< HEAD
         similarity_threshold: float | None = None,
     ) -> "LSIRetriever":
         """Restore a fitted retriever from persisted artifacts.
 
         Loads TF-IDF vectorizer and SVD model from disk.
-=======
-        max_spell_distance: int = 2,
-        similarity_threshold: float | None = None,
-    ) -> "LSIRetriever":
-        """Restore a fitted retriever from persisted artifacts.
-
-        Loads TF-IDF vectorizer and SVD model from disk, and rebuilds
-        the spell checker from the TF-IDF vocabulary.
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 
         Args:
             repository: Vector storage backend.
             document_store: Full text storage backend.
+            text_processor: TextProcessor for query preprocessing.
             model_dir: Directory containing saved artifacts.
-<<<<<<< HEAD
             similarity_threshold: Minimum similarity score for results.
                 If None, uses DEFAULT_SIMILARITY_THRESHOLD.
-=======
-            max_spell_distance: Max edit distance for spelling correction.
-<<<<<<< HEAD
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
-=======
-            similarity_threshold: Minimum similarity score for results.
-                If None, uses DEFAULT_SIMILARITY_THRESHOLD.
->>>>>>> d9ec2fc (feat: Enhance document storage and retrieval with error handling and new methods)
 
         Returns:
-            Ready-to-use ``LSIRetriever`` instance.
+            Ready-to-use LSIRetriever instance.
         """
         instance = cls(
             repository=repository,
             document_store=document_store,
+            text_processor=text_processor,
             model_dir=model_dir,
-<<<<<<< HEAD
             similarity_threshold=similarity_threshold,
         )
         instance.tfidf = TfidfProcessor.load(model_dir)
         instance.model = LSIModel.load(model_dir)
         return instance
-
-=======
-            max_spell_distance=max_spell_distance,
-            similarity_threshold=similarity_threshold,
-        )
-        instance.tfidf = TfidfProcessor.load(model_dir)
-        instance.model = LSIModel.load(model_dir)
-
-        # Rebuild spell checker from the loaded TF-IDF vocabulary
-        vocab = instance.tfidf.vocabulary
-        instance.spell_checker = TrieSpellChecker(
-            vocabulary=vocab,
-            max_distance=max_spell_distance,
-        )
-        return instance
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    def _normalize_query(self, text: str) -> str:
-        """Apply basic cleaning and spell correction to query text."""
-        text = text.lower().strip()
-        text = re.sub(r"[^\w\s]", "", text)
-        if self.spell_checker:
-            words = text.split()
-            corrected = [self.spell_checker.correct(w) or w for w in words]
-            return " ".join(corrected)
-        return text
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)

--- a/modules/retriever/service.py
+++ b/modules/retriever/service.py
@@ -4,20 +4,15 @@ This is the main entry-point for retrieval. It implements a two-tier storage arc
     - Vector DB (ChromaDB): Stores doc IDs + embeddings for fast similarity search
     - Document Store: Stores full document text and metadata
 
-Retrieval pipeline:
-    Query (raw text) → TextProcessor.process(is_query=True)
-                    → TfidfProcessor.transform()
-                    → LSIModel.project_query()
-                    → ChromaRepository.search_similar()
-                    → DocumentStore.get_by_ids()
-                    → RetrievedDocument list (ranked)
+Retrieval flow:
+    IndexedCorpus (docs) → TfidfProcessor.fit() → LSIModel.fit() → store vectors
+    IndexedCorpus (query) → TfidfProcessor.transform() → LSIModel.project() → search
 """
 
 from __future__ import annotations
 
 from core.interfaces import BaseRetriever, BaseRepository, DocumentStore, IndexedCorpus
 from core.models import Query, RetrievedDocument
-from modules.text_processor import TextProcessor
 
 from .lsi_model import LSIModel
 from .tfidf_processor import TfidfProcessor
@@ -27,11 +22,10 @@ class LSIRetriever(BaseRetriever):
     """Retriever based on TF-IDF + TruncatedSVD (LSI) with two-tier storage.
 
     Orchestrates:
-        1. TextProcessor     — normalizes and preprocesses query text.
-        2. TfidfProcessor    — builds/queries the TF-IDF matrix.
-        3. LSIModel          — reduces dimensionality via SVD.
-        4. BaseRepository    — stores/searches document vectors (ChromaDB).
-        5. DocumentStore     — stores full document text and metadata.
+        1. TfidfProcessor    — builds/queries the TF-IDF matrix.
+        2. LSIModel          — reduces dimensionality via SVD.
+        3. BaseRepository    — stores/searches document vectors (ChromaDB).
+        4. DocumentStore     — stores full document text and metadata.
 
     Storage architecture:
         - Vector DB: ID + embedding + URL (for fast similarity search)
@@ -45,12 +39,8 @@ class LSIRetriever(BaseRetriever):
         self,
         repository: BaseRepository,
         document_store: DocumentStore,
-        text_processor: TextProcessor | None = None,
         model_dir: str = "models/lsi",
         n_components: int = 100,
-        tfidf_max_features: int | None = 10_000,
-        tfidf_min_df: int = 1,
-        tfidf_max_df: float = 0.95,
         similarity_threshold: float | None = None,
     ) -> None:
         """Initialize with repository, document store, and hyper-parameters.
@@ -58,21 +48,14 @@ class LSIRetriever(BaseRetriever):
         Args:
             repository: Vector storage backend (e.g. ChromaRepository).
             document_store: Full text storage backend (e.g. FileSystemDocumentStore).
-            text_processor: TextProcessor for query preprocessing. If None, must be
-                set via set_text_processor() before calling retrieve().
             model_dir: Directory for persisting model artifacts.
             n_components: Number of latent LSI dimensions.
-            tfidf_max_features: Cap on TF-IDF vocabulary size (ignored when
-                the corpus supplies its own vocabulary).
-            tfidf_min_df: Minimum document frequency for TF-IDF terms.
-            tfidf_max_df: Maximum document frequency for TF-IDF terms.
             similarity_threshold: Minimum similarity score (0-1) for results.
                 Results below this threshold are filtered out. If None, uses
                 DEFAULT_SIMILARITY_THRESHOLD (0.4).
         """
         self.repository = repository
         self.document_store = document_store
-        self.text_processor = text_processor
         self.model_dir = model_dir
         self.n_components = n_components
         self.similarity_threshold = (
@@ -85,19 +68,6 @@ class LSIRetriever(BaseRetriever):
         self.tfidf: TfidfProcessor | None = None
         self.model: LSIModel | None = None
 
-        # Store TF-IDF hyperparameters for deferred construction
-        self._tfidf_max_features = tfidf_max_features
-        self._tfidf_min_df = tfidf_min_df
-        self._tfidf_max_df = tfidf_max_df
-
-    def set_text_processor(self, text_processor: TextProcessor) -> None:
-        """Set or override the TextProcessor for query preprocessing.
-
-        Args:
-            text_processor: TextProcessor instance for query preprocessing.
-        """
-        self.text_processor = text_processor
-
     # ------------------------------------------------------------------
     # Training
     # ------------------------------------------------------------------
@@ -106,7 +76,7 @@ class LSIRetriever(BaseRetriever):
         """Fit the full retrieval pipeline from an indexed corpus.
 
         Steps:
-            1. Build TF-IDF matrix from the IndexedCorpus.
+            1. Build TF-IDF matrix from the IndexedCorpus (uses inverted_index).
             2. Fit LSI (SVD) on the TF-IDF matrix → document vectors.
             3. Store documents in document store (full text + metadata).
             4. Store IDs + vectors + URLs in vector repository.
@@ -115,12 +85,8 @@ class LSIRetriever(BaseRetriever):
             corpus: Preprocessed corpus from the indexer, containing
                 documents, processed texts, inverted index, and vocabulary.
         """
-        # 1. TF-IDF - build matrix from indexed corpus
-        self.tfidf = TfidfProcessor(
-            max_features=self._tfidf_max_features,
-            min_df=self._tfidf_min_df,
-            max_df=self._tfidf_max_df,
-        )
+        # 1. TF-IDF - build matrix from inverted index
+        self.tfidf = TfidfProcessor()
         tfidf_matrix = self.tfidf.fit(corpus)
 
         # 2. LSI
@@ -145,16 +111,19 @@ class LSIRetriever(BaseRetriever):
     ) -> list[RetrievedDocument]:
         """Retrieve the top-k most relevant documents for a query.
 
-        Pipeline:
-            1. Preprocess query using TextProcessor (normalize, tokenize, lemmatize)
-            2. Transform to TF-IDF vector
-            3. Project to LSI latent space
-            4. Search ChromaDB for similar documents
-            5. Fetch full documents from DocumentStore
-            6. Filter by similarity threshold and return ranked results
+        Two-phase retrieval:
+            1. Vector similarity search → returns doc IDs and scores
+            2. Fetch full documents from document store by IDs
+
+        Results are filtered by similarity threshold and returned in ranked order
+        (highest score first).
+
+        The query must contain an IndexedCorpus (built by the pipeline).
+        The TF-IDF processor filters terms not in its vocabulary, then
+        projects through LSI for vector search.
 
         Args:
-            query: User query with text string.
+            query: User query with indexed_corpus populated.
             top_k: Maximum number of results to return.
             threshold: Minimum similarity score (0-1) for results. If None,
                 uses the instance's similarity_threshold. Results below this
@@ -166,26 +135,24 @@ class LSIRetriever(BaseRetriever):
 
         Raises:
             RuntimeError: If the retriever has not been fitted or loaded.
-            RuntimeError: If TextProcessor is not set and needed.
+            ValueError: If query.indexed_corpus is None.
         """
         if self.tfidf is None or self.model is None:
             raise RuntimeError(
                 "Retriever must be fitted or loaded before use."
             )
 
+        if query.indexed_corpus is None:
+            raise ValueError(
+                "Query must have indexed_corpus populated. "
+                "Build it with the indexer before calling retrieve()."
+            )
+
         # Use provided threshold or fall back to instance default
         min_score = threshold if threshold is not None else self.similarity_threshold
 
-        # Phase 1: Preprocess query text
-        if self.text_processor is not None:
-            # Full preprocessing: normalize, tokenize, lemmatize, spell check
-            processed_query = self.text_processor.process(query.text, is_query=True)
-        else:
-            # Fallback: minimal preprocessing (assumes query is already somewhat clean)
-            processed_query = query.text.lower().strip()
-
-        # Phase 2: Vector similarity search
-        query_tfidf = self.tfidf.transform(processed_query)
+        # Phase 1: Vector similarity search
+        query_tfidf = self.tfidf.transform(query.indexed_corpus)
         query_vector = self.model.project_query(query_tfidf)
 
         # Get ranked (doc_id, score) pairs from vector DB
@@ -202,7 +169,7 @@ class LSIRetriever(BaseRetriever):
         if not filtered_results:
             return []
 
-        # Phase 3: Fetch full documents from document store
+        # Phase 2: Fetch full documents from document store
         doc_ids = [doc_id for doc_id, _ in filtered_results]
         score_map = {doc_id: score for doc_id, score in filtered_results}
 
@@ -243,7 +210,6 @@ class LSIRetriever(BaseRetriever):
         cls,
         repository: BaseRepository,
         document_store: DocumentStore,
-        text_processor: TextProcessor | None = None,
         model_dir: str = "models/lsi",
         similarity_threshold: float | None = None,
     ) -> "LSIRetriever":
@@ -254,21 +220,20 @@ class LSIRetriever(BaseRetriever):
         Args:
             repository: Vector storage backend.
             document_store: Full text storage backend.
-            text_processor: TextProcessor for query preprocessing.
             model_dir: Directory containing saved artifacts.
             similarity_threshold: Minimum similarity score for results.
                 If None, uses DEFAULT_SIMILARITY_THRESHOLD.
 
         Returns:
-            Ready-to-use LSIRetriever instance.
+            Ready-to-use ``LSIRetriever`` instance.
         """
         instance = cls(
             repository=repository,
             document_store=document_store,
-            text_processor=text_processor,
             model_dir=model_dir,
             similarity_threshold=similarity_threshold,
         )
         instance.tfidf = TfidfProcessor.load(model_dir)
         instance.model = LSIModel.load(model_dir)
         return instance
+

--- a/modules/retriever/tfidf_processor.py
+++ b/modules/retriever/tfidf_processor.py
@@ -1,7 +1,7 @@
-"""TF-IDF processor that consumes precomputed data from the indexer.
+"""TF-IDF processor - builds sparse matrix from IndexedCorpus.
 
-This module sits between the indexer and the LSI model:
-    IndexedCorpus (adapter) → TfidfProcessor → sparse matrix → LSIModel
+Receives IndexedCorpus for both documents and queries.
+Filters query terms that are not in the document vocabulary.
 """
 
 from __future__ import annotations
@@ -9,137 +9,119 @@ from __future__ import annotations
 from pathlib import Path
 
 import joblib
-
-from scipy.sparse import spmatrix
-from sklearn.feature_extraction.text import TfidfVectorizer
+import numpy as np
+from scipy.sparse import csr_matrix, spmatrix
 
 from core.interfaces import IndexedCorpus
 
 
 class TfidfProcessor:
-    """Builds and holds a TF-IDF matrix from an IndexedCorpus.
+    """Builds TF-IDF matrix from IndexedCorpus.
 
-    The processor respects the vocabulary provided by the indexer
-    (via ``IndexedCorpus.vocabulary``).  If the indexer returns
-    ``None``, the vectorizer discovers the vocabulary automatically.
-
-    Typical usage::
-
-        corpus: IndexedCorpus = indexer.build()   # future
-        tfidf = TfidfProcessor()
-        matrix = tfidf.fit(corpus)                # sparse (docs × terms)
-        query_vec = tfidf.transform("headache")   # sparse (1 × terms)
+    Both documents and queries come as IndexedCorpus.
+    Query terms not in the document vocabulary are filtered out.
     """
 
-    def __init__(
-        self,
-        max_features: int | None = 10_000,
-        min_df: int = 1,
-        max_df: float = 0.95,
-    ) -> None:
-        """Initialize vectorizer hyper-parameters.
-
-        Args:
-            max_features: Cap on vocabulary size.  Ignored when the corpus
-                provides an explicit vocabulary.
-            min_df: Minimum document frequency for a term.
-            max_df: Maximum document frequency (as fraction).
-        """
-        self._max_features = max_features
-        self._min_df = min_df
-        self._max_df = max_df
-
-        self._vectorizer: TfidfVectorizer | None = None
-        self._fitted = False
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
+    def __init__(self) -> None:
+        self._vocabulary: list[str] | None = None
+        self._term_to_idx: dict[str, int] | None = None
+        self._idf: np.ndarray | None = None
+        self._n_docs: int = 0
 
     def fit(self, corpus: IndexedCorpus) -> spmatrix:
-        """Build the TF-IDF matrix from the indexed corpus.
-
-        If the corpus supplies an explicit vocabulary the vectorizer will
-        use it (and ``max_features`` / ``min_df`` / ``max_df`` are
-        effectively overridden).  Otherwise the vectorizer discovers the
-        vocabulary from the preprocessed texts.
+        """Build TF-IDF matrix from document corpus.
 
         Args:
-            corpus: An object implementing ``IndexedCorpus``.
+            corpus: IndexedCorpus with documents, inverted_index, vocabulary.
 
         Returns:
-            Sparse TF-IDF matrix of shape ``(n_documents, n_terms)``.
+            Sparse TF-IDF matrix (n_docs × n_terms).
         """
-        vocab = corpus.vocabulary
+        self._n_docs = len(corpus.documents)
+        self._vocabulary = corpus.vocabulary
+        self._term_to_idx = {term: idx for idx, term in enumerate(self._vocabulary)}
 
-        if vocab is not None:
-            # Indexer provides an explicit vocabulary — honour it.
-            self._vectorizer = TfidfVectorizer(vocabulary=vocab)
-        else:
-            self._vectorizer = TfidfVectorizer(
-                max_features=self._max_features,
-                min_df=self._min_df,
-                max_df=self._max_df,
-            )
+        # Compute IDF: log((N+1) / (df+1)) + 1
+        self._idf = np.zeros(len(self._vocabulary), dtype=np.float32)
+        for term_idx, term in enumerate(self._vocabulary):
+            df = len(corpus.inverted_index.get(term, []))
+            self._idf[term_idx] = np.log((self._n_docs + 1) / (df + 1)) + 1.0
 
-        tfidf_matrix: spmatrix = self._vectorizer.fit_transform(
-            corpus.processed_texts,
+        # Build sparse matrix: TF-IDF = TF * IDF
+        rows, cols, data = [], [], []
+        for term, postings in corpus.inverted_index.items():
+            if term not in self._term_to_idx:
+                continue
+            term_idx = self._term_to_idx[term]
+            term_idf = self._idf[term_idx]
+            for doc_idx, tf in postings:
+                rows.append(doc_idx)
+                cols.append(term_idx)
+                data.append(tf * term_idf)
+
+        return csr_matrix(
+            (data, (rows, cols)),
+            shape=(self._n_docs, len(self._vocabulary)),
+            dtype=np.float32,
         )
-        self._fitted = True
-        return tfidf_matrix
 
-    def transform(self, text: str) -> spmatrix:
-        """Project a single text into the fitted TF-IDF space.
+    def transform(self, query_corpus: IndexedCorpus) -> spmatrix:
+        """Transform query corpus to TF-IDF vector.
 
         Args:
-            text: Raw or preprocessed query text.
+            query_corpus: IndexedCorpus with 1 document (the query).
+                Terms not in the document vocabulary are filtered out.
 
         Returns:
-            Sparse TF-IDF vector of shape ``(1, n_terms)``.
-
-        Raises:
-            RuntimeError: If called before ``fit``.
+            Sparse TF-IDF vector (1 × n_terms).
         """
-        if not self._fitted or self._vectorizer is None:
-            raise RuntimeError("TfidfProcessor must be fitted before transform.")
-        return self._vectorizer.transform([text])
+        if self._term_to_idx is None or self._idf is None:
+            raise RuntimeError("Must call fit() before transform()")
+
+        # Query comes as IndexedCorpus with 1 document
+        # Extract term frequencies from inverted_index
+        indices, data = [], []
+
+        for term, postings in query_corpus.inverted_index.items():
+            # Filter: only terms in document vocabulary
+            if term not in self._term_to_idx:
+                continue
+
+            # Get term frequency for the query (first posting, first doc)
+            if postings:
+                tf = postings[0][1]  # (doc_idx, freq) -> freq
+                term_idx = self._term_to_idx[term]
+                indices.append(term_idx)
+                data.append(tf * self._idf[term_idx])
+
+        return csr_matrix(
+            (data, ([0] * len(data), indices)),
+            shape=(1, len(self._vocabulary)),
+            dtype=np.float32,
+        )
 
     @property
     def vocabulary(self) -> list[str]:
-        """Return the fitted vocabulary as an ordered list of terms.
-
-        Useful for initializing the spell-checker with corpus terms.
-        """
-        if not self._fitted or self._vectorizer is None:
-            raise RuntimeError("TfidfProcessor must be fitted first.")
-        return list(self._vectorizer.get_feature_names_out())
-
-    # ------------------------------------------------------------------
-    # Persistence
-    # ------------------------------------------------------------------
+        """Return fitted vocabulary."""
+        if self._vocabulary is None:
+            raise RuntimeError("Must call fit() first")
+        return self._vocabulary
 
     def save(self, path: str | Path) -> None:
-        """Persist the fitted vectorizer to disk.
-
-        Args:
-            path: Directory where ``tfidf.joblib`` will be written.
-        """
-        path = Path(path)
-        path.mkdir(parents=True, exist_ok=True)
-        joblib.dump(self._vectorizer, path / "tfidf.joblib")
+        """Save model to disk."""
+        Path(path).mkdir(parents=True, exist_ok=True)
+        joblib.dump(
+            {"vocabulary": self._vocabulary, "idf": self._idf, "n_docs": self._n_docs},
+            Path(path) / "tfidf.joblib",
+        )
 
     @classmethod
     def load(cls, path: str | Path) -> "TfidfProcessor":
-        """Restore a fitted TfidfProcessor from disk.
-
-        Args:
-            path: Directory containing ``tfidf.joblib``.
-
-        Returns:
-            A ready-to-use TfidfProcessor instance.
-        """
-        path = Path(path)
+        """Load model from disk."""
+        data = joblib.load(Path(path) / "tfidf.joblib")
         instance = cls()
-        instance._vectorizer = joblib.load(path / "tfidf.joblib")
-        instance._fitted = True
+        instance._vocabulary = data["vocabulary"]
+        instance._idf = data["idf"]
+        instance._n_docs = data["n_docs"]
+        instance._term_to_idx = {t: i for i, t in enumerate(instance._vocabulary)}
         return instance

--- a/modules/retriever/tfidf_processor.py
+++ b/modules/retriever/tfidf_processor.py
@@ -1,14 +1,7 @@
-<<<<<<< HEAD
-"""TF-IDF processor - builds sparse matrix from IndexedCorpus.
-
-Receives IndexedCorpus for both documents and queries.
-Filters query terms that are not in the document vocabulary.
-=======
 """TF-IDF processor that consumes precomputed data from the indexer.
 
 This module sits between the indexer and the LSI model:
     IndexedCorpus (adapter) → TfidfProcessor → sparse matrix → LSIModel
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 """
 
 from __future__ import annotations
@@ -16,128 +9,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import joblib
-<<<<<<< HEAD
-import numpy as np
-from scipy.sparse import csr_matrix, spmatrix
-=======
+
 from scipy.sparse import spmatrix
 from sklearn.feature_extraction.text import TfidfVectorizer
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 
 from core.interfaces import IndexedCorpus
 
 
 class TfidfProcessor:
-<<<<<<< HEAD
-    """Builds TF-IDF matrix from IndexedCorpus.
-
-    Both documents and queries come as IndexedCorpus.
-    Query terms not in the document vocabulary are filtered out.
-    """
-
-    def __init__(self) -> None:
-        self._vocabulary: list[str] | None = None
-        self._term_to_idx: dict[str, int] | None = None
-        self._idf: np.ndarray | None = None
-        self._n_docs: int = 0
-
-    def fit(self, corpus: IndexedCorpus) -> spmatrix:
-        """Build TF-IDF matrix from document corpus.
-
-        Args:
-            corpus: IndexedCorpus with documents, inverted_index, vocabulary.
-
-        Returns:
-            Sparse TF-IDF matrix (n_docs × n_terms).
-        """
-        self._n_docs = len(corpus.documents)
-        self._vocabulary = corpus.vocabulary
-        self._term_to_idx = {term: idx for idx, term in enumerate(self._vocabulary)}
-
-        # Compute IDF: log((N+1) / (df+1)) + 1
-        self._idf = np.zeros(len(self._vocabulary), dtype=np.float32)
-        for term_idx, term in enumerate(self._vocabulary):
-            df = len(corpus.inverted_index.get(term, []))
-            self._idf[term_idx] = np.log((self._n_docs + 1) / (df + 1)) + 1.0
-
-        # Build sparse matrix: TF-IDF = TF * IDF
-        rows, cols, data = [], [], []
-        for term, postings in corpus.inverted_index.items():
-            if term not in self._term_to_idx:
-                continue
-            term_idx = self._term_to_idx[term]
-            term_idf = self._idf[term_idx]
-            for doc_idx, tf in postings:
-                rows.append(doc_idx)
-                cols.append(term_idx)
-                data.append(tf * term_idf)
-
-        return csr_matrix(
-            (data, (rows, cols)),
-            shape=(self._n_docs, len(self._vocabulary)),
-            dtype=np.float32,
-        )
-
-    def transform(self, query_corpus: IndexedCorpus) -> spmatrix:
-        """Transform query corpus to TF-IDF vector.
-
-        Args:
-            query_corpus: IndexedCorpus with 1 document (the query).
-                Terms not in the document vocabulary are filtered out.
-
-        Returns:
-            Sparse TF-IDF vector (1 × n_terms).
-        """
-        if self._term_to_idx is None or self._idf is None:
-            raise RuntimeError("Must call fit() before transform()")
-
-        # Query comes as IndexedCorpus with 1 document
-        # Extract term frequencies from inverted_index
-        indices, data = [], []
-
-        for term, postings in query_corpus.inverted_index.items():
-            # Filter: only terms in document vocabulary
-            if term not in self._term_to_idx:
-                continue
-
-            # Get term frequency for the query (first posting, first doc)
-            if postings:
-                tf = postings[0][1]  # (doc_idx, freq) -> freq
-                term_idx = self._term_to_idx[term]
-                indices.append(term_idx)
-                data.append(tf * self._idf[term_idx])
-
-        return csr_matrix(
-            (data, ([0] * len(data), indices)),
-            shape=(1, len(self._vocabulary)),
-            dtype=np.float32,
-        )
-
-    @property
-    def vocabulary(self) -> list[str]:
-        """Return fitted vocabulary."""
-        if self._vocabulary is None:
-            raise RuntimeError("Must call fit() first")
-        return self._vocabulary
-
-    def save(self, path: str | Path) -> None:
-        """Save model to disk."""
-        Path(path).mkdir(parents=True, exist_ok=True)
-        joblib.dump(
-            {"vocabulary": self._vocabulary, "idf": self._idf, "n_docs": self._n_docs},
-            Path(path) / "tfidf.joblib",
-        )
-
-    @classmethod
-    def load(cls, path: str | Path) -> "TfidfProcessor":
-        """Load model from disk."""
-        data = joblib.load(Path(path) / "tfidf.joblib")
-        instance = cls()
-        instance._vocabulary = data["vocabulary"]
-        instance._idf = data["idf"]
-        instance._n_docs = data["n_docs"]
-        instance._term_to_idx = {t: i for i, t in enumerate(instance._vocabulary)}
-=======
     """Builds and holds a TF-IDF matrix from an IndexedCorpus.
 
     The processor respects the vocabulary provided by the indexer
@@ -263,5 +142,4 @@ class TfidfProcessor:
         instance = cls()
         instance._vectorizer = joblib.load(path / "tfidf.joblib")
         instance._fitted = True
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
         return instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,9 @@ scipy>=1.13.0
 scikit-learn>=1.5.0          # TF-IDF, TruncatedSVD for LSI model
 sentence-transformers>=3.0.0  # Embeddings for RAG and semantic search
 nltk>=3.8.0                  # Natural language processing utilities
-<<<<<<< HEAD
 spacy>=3.7.0                 # Industrial-strength NLP with POS tagging and lemmatization
 # Note: After installing spacy, download the Spanish model with:
 #   python -m spacy download es_core_news_md
-=======
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 
 # Persistence & Serialization
 joblib>=1.4.0                # Model persistence
@@ -30,14 +27,12 @@ python-dotenv>=1.0.0         # Environment configuration
 # Web Crawling & HTTP
 requests>=2.31.0             # HTTP library for web requests
 beautifulsoup4>=4.12.0       # HTML/XML parsing for crawler
+lxml>=4.9.0                  # Fast HTML/XML parser (required by BeautifulSoup scrapers)
 
-<<<<<<< HEAD
 # Document Loading (optional formats)
 unstructured>=0.10.0         # HTML parsing for DocumentLoader
 pypdf>=3.17.0                # PDF parsing for DocumentLoader
 
-=======
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 # User Interface (optional, for Corte 3)
 streamlit>=1.28.0            # Streamlit for UI or
 # gradio>=3.50.0             # Alternative: Gradio for UI
@@ -45,12 +40,9 @@ streamlit>=1.28.0            # Streamlit for UI or
 # Testing & Development
 pytest>=8.2.0                # Unit testing framework
 pytest-cov>=4.1.0            # Coverage reporting for tests
-<<<<<<< HEAD
 pytest-xdist>=3.5.0          # Parallel test execution
 pytest-mock>=3.12.0          # Mock and patch utilities for testing
 mock>=5.1.0                  # Mock library for creating test doubles
-=======
->>>>>>> 2491ed1 (feat: Enhance LSI retrieval system with new data structures and storage layers)
 
 # Utilities
 python-dateutil>=2.8.0       # Date utilities


### PR DESCRIPTION
## Summary

- Implements the full crawler module (`modules/crawler/`) with sitemap-based URL
  discovery, robots.txt enforcement, per-domain rate limiting, and retry logic
- Adds three site-specific scrapers: Mayo Clinic, MedlinePlus, and NHS
- Persists extracted documents as JSONL files in `data/raw/` (one file per source)
- Resolves conflict markers left in `requirements.txt` and adds `lxml` dependency
- Adds integration guide for the indexer at `docs/crawler-output-guide.md`

## Test plan

- [X] Run live crawl smoke test with `max_pages=5` per source and verify `data/raw/*.jsonl` are generated
- [X] Confirm all imports resolve: `from modules.crawler import CrawlerService, CrawlConfig`
- [X] Verify `requirements.txt` has no conflict markers
