### PR TITLE
feat(rag): migrate from Gemini to Groq API for answer generation

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -88,7 +88,7 @@ class RAGResponse:
         profile_type: The profile that shaped the generation.
         sources: Documents used as context for generation.
         used_llm: True if an LLM produced the answer; False if template fallback.
-        model_name: LLM model identifier (e.g. "gemini-1.5-flash"), or
+        model_name: LLM model identifier (e.g. "llama-3.1-8b-instant"), or
             "template_fallback" when the LLM was unavailable.
         query_text: Original query text — stored for logging/display.
     """

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - SRI_ENV=production
-      - GEMINI_API_KEY=${GEMINI_API_KEY:-}  # Set via .env or inline
+      - GROQ_API_KEY=${GROQ_API_KEY:-}  # Set via .env or inline
     networks:
       - sri-network
     restart: unless-stopped

--- a/docs/RAG_GUIDE.md
+++ b/docs/RAG_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Introducción
 
-El módulo RAG (Retrieval-Augmented Generation) de ShealtRI genera respuestas médicas **adaptadas al perfil del usuario**. Cada usuario se identifica con uno de 6 roles, y el sistema ajusta automáticamente el tono, vocabulario y nivel de detalle de la respuesta.
+El módulo RAG (Retrieval-Augmented Generation) de ShealtRI genera respuestas médicas **adaptadas al perfil del usuario**. Cada usuario se identifica con uno de 6 roles, y el sistema ajusta automáticamente el tono, vocabulario y nivel de detalle de la respuesta. Las respuestas son generadas por el modelo **Llama 3.1 8B** a través de la API de **Groq**, ofreciendo un tier gratuito generoso (30 req/min, ~14,400 req/día).
 
 ## Perfiles Soportados
 
@@ -48,7 +48,7 @@ Query> síntomas de diabetes
        http://example.com/treatment
        ...
 
-  ──── Respuesta generada [Estudiante De Medicina | gemini-1.5-flash] ────
+  ──── Respuesta generada [Estudiante De Medicina | llama-3.1-8b-instant] ────
   
   La diabetes mellitus es un trastorno metabólico caracterizado por
   defectos en la secreción de insulina y/o resistencia periférica...
@@ -94,7 +94,7 @@ RAGService.generate()
     ├─→ ProfileRegistry.get(profile_type)
     ├─→ build_context_block(docs)
     ├─→ render_prompt(profile_config, query, context)
-    ├─→ _call_gemini(prompt)
+    ├─→ _call_llm(prompt)
     │   ├─ API Success → answer_text
     │   └─ API Error → "" (fallback)
     ├─→ build_fallback_response() [si no hubo API]
@@ -109,14 +109,14 @@ Registro inmutable de las 6 configuraciones de perfil. Cada perfil tiene:
 - `tone`: Descripción del tono vocal
 - `vocabulary_level`: Nivel de tecnicismo
 - `focus_areas`: Áreas de enfoque prioritario
-- `system_prompt`: Plantilla de instrucción para Gemini
+- `system_prompt`: Plantilla de instrucción para Groq
 
 #### `RAGService(BaseRAG)`
 Implementa la interfaz `BaseRAG`. Encargado de:
 1. Resolver el perfil (default a PATIENT si no hay)
 2. Construir bloque de contexto desde documentos
 3. Renderizar el prompt con placeholders {query}, {context}, {focus_areas}
-4. Llamar a Gemini API (o fallback si no hay API key)
+4. Llamar a Groq API (o fallback si no hay API key)
 5. Retornar `RAGResponse` con provenance
 
 #### `build_context_block(docs, max_docs=3)`
@@ -132,14 +132,14 @@ Renderiza el prompt usando `str.format_map` con:
 - `{focus_areas}`: áreas de enfoque del perfil
 
 #### `build_fallback_response(profile_config, query_text, docs)`
-Genera una respuesta template-based adaptada al perfil cuando Gemini no está disponible.
+Genera una respuesta template-based adaptada al perfil cuando Groq no está disponible.
 
 ### Configuración
 
-#### Variable de entorno: `GEMINI_API_KEY`
+#### Variable de entorno: `GROQ_API_KEY`
 
-La API key de Gemini se configura vía:
-1. Variable de entorno `GEMINI_API_KEY`
+La API key de Groq se configura vía:
+1. Variable de entorno `GROQ_API_KEY`
 2. Parámetro `api_key` en el constructor de `RAGService`
 
 Si ninguno está seteado, el sistema usa fallback (respuestas template).
@@ -147,21 +147,27 @@ Si ninguno está seteado, el sistema usa fallback (respuestas template).
 En Docker Compose:
 ```yaml
 environment:
-  - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+  - GROQ_API_KEY=${GROQ_API_KEY:-}
 ```
 
 Ejecutar con API key:
 ```bash
-export GEMINI_API_KEY="gsk_..."
+export GROQ_API_KEY="gsk_..."
 python cli.py --query "fiebre alta" --profile paciente
 ```
 
-#### Parámetros de Gemini
+Para obtener una API key de Groq:
+1. Visita https://console.groq.com/keys
+2. Crea una cuenta gratuita o inicia sesión
+3. Genera una nueva API key
+4. Cópiala a tu archivo `.env` en la variable `GROQ_API_KEY`
 
-En `RAGService._call_gemini()`:
+#### Parámetros de Groq
+
+En `RAGService._call_llm()`:
 - `temperature: 0.3` — bajo para respuestas factuales
 - `top_p: 0.9` — diversidad controlada
-- `max_output_tokens: 512` — aproximadamente 400 palabras en español
+- `max_tokens: 512` — aproximadamente 400 palabras en español
 
 ## Ejemplos de Uso
 
@@ -189,7 +195,7 @@ $ python cli.py --profile estudiante --query "mecanismo de acción de la metform
 
 [Retrievals...]
 
-  ──── Respuesta generada [Estudiante De Medicina | gemini-1.5-flash] ────
+  ──── Respuesta generada [Estudiante De Medicina | llama-3.1-8b-instant] ────
 
   La metformina es un agente antihiperglucemiante de la clase de las
   biguanidas. Su mecanismo principal es:
@@ -203,7 +209,7 @@ $ python cli.py --profile estudiante --query "mecanismo de acción de la metform
 ```bash
 $ python cli.py --profile diagnostico --query "cefalea progresiva con fotofobia"
 
-  ──── Respuesta generada [Diagnostico Asistido | gemini-1.5-flash] ────
+  ──── Respuesta generada [Diagnostico Asistido | llama-3.1-8b-instant] ────
 
   **Diagnósticos más probables:**
   1. Migraña — fotofobia y cefalea progresiva son hallazgos típicos
@@ -223,9 +229,9 @@ $ python cli.py --profile diagnostico --query "cefalea progresiva con fotofobia"
   - Cambios en la conciencia
 ```
 
-## Fallback: Comportamiento sin Gemini API
+## Fallback: Comportamiento sin Groq API
 
-Si `GEMINI_API_KEY` no está seteada o la API falla:
+Si `GROQ_API_KEY` no está seteada o la API falla:
 
 1. El sistema sigue funcionando normalmente
 2. Las respuestas se generan con plantillas adaptadas al perfil
@@ -256,7 +262,7 @@ python -m pytest tests/integration/test_rag_pipeline.py -v
 ```
 
 Cubre:
-- Flujo end-to-end sin Gemini API
+- Flujo end-to-end sin Groq API
 - Adaptación de respuestas a perfiles
 - Manejo de listas vacías
 - Respeto a límites de documentos
@@ -309,20 +315,20 @@ El sistema viene con 6 perfiles predefinidos. Para agregar más:
 ## Notas Importantes
 
 1. **Sin API key**: El sistema funciona con fallback, pero sin respuestas generadas por LLM.
-2. **Tasa límite de Gemini**: El tier gratuito permite 15 req/min y 1500/día — suficiente para desarrollo y defensa.
-3. **Lenguaje**: Todas las respuestas están en español. Las instrucciones a Gemini están en español.
-4. **Reproducibilidad**: Sin servicios en la nube (excepto Gemini API). Todo corre localmente.
+2. **Tasa límite de Groq**: El tier gratuito permite 30 req/min y ~14,400 req/día — muy generoso para desarrollo, testing y defensa.
+3. **Lenguaje**: Todas las respuestas están en español. Las instrucciones a Groq están en español.
+4. **Reproducibilidad**: Sin servicios en la nube (excepto Groq API). Todo corre localmente.
 
 ## Preguntas Frecuentes
 
-**P: ¿Qué pasa si Gemini está muy lento?**
+**P: ¿Qué pasa si Groq está muy lento?**
 A: El `timeout` es de 60 segundos. Si se excede, se usa fallback.
 
-**P: ¿Puedo cambiar el modelo de Gemini?**
-A: Sí, pasar `model_name="gemini-2.0-flash"` al constructor de `RAGService`.
+**P: ¿Puedo cambiar el modelo de Groq?**
+A: Sí, pasar `model_name="mixtral-8x7b-32768"` u otro modelo disponible al constructor de `RAGService`. Los modelos disponibles están en https://console.groq.com/docs/models.
 
 **P: ¿Cómo agrego más perfiles?**
 A: Ver sección "Crear un perfil personalizado" arriba.
 
 **P: ¿El fallback es bueno?**
-A: Es funcional y informativo, pero no tan pulido como Gemini. La API key es gratuita.
+A: Es funcional e informativo, pero no tan pulido como Groq. La API key es gratuita y no requiere tarjeta de crédito.

--- a/modules/rag/service.py
+++ b/modules/rag/service.py
@@ -1,14 +1,14 @@
-"""RAGService — profile-aware answer generation using Google Gemini API.
+"""RAGService — profile-aware answer generation using Groq API.
 
 Architecture:
     1. Read user profile from query.user_profile (fall back to PATIENT).
     2. Build context block from retrieved documents.
     3. Render prompt using the profile's system_prompt template.
-    4. Call Gemini API to generate an answer.
+    4. Call Groq API to generate an answer.
     5. On any API failure, fall back to template-based response.
     6. Return RAGResponse with provenance metadata.
 
-Gemini is called via the google-genai SDK (google.generativeai is deprecated).
+Groq is called via the groq SDK with OpenAI-compatible chat.completions interface.
 """
 
 from __future__ import annotations
@@ -38,51 +38,53 @@ _FALLBACK_MODEL_NAME = "template_fallback"
 
 
 class RAGService(BaseRAG):
-    """Profile-aware RAG using Google Gemini API as the LLM backend.
+    """Profile-aware RAG using Groq API as the LLM backend.
 
     Attributes:
-        api_key: Gemini API key from environment or constructor.
-        model_name: Gemini model to use (e.g. "gemini-1.5-flash").
+        api_key: Groq API key from environment or constructor.
+        model_name: Groq model to use (e.g. "llama-3.1-8b-instant").
         max_context_docs: Max retrieved documents included in the prompt.
     """
 
     def __init__(
         self,
         api_key: str | None = None,
-        model_name: str = "gemini-1.5-flash",
+        model_name: str | None = None,
         max_context_docs: int = 3,
     ) -> None:
         """Initialize the RAG service.
 
         Args:
-            api_key: Gemini API key. If None, reads from GEMINI_API_KEY
+            api_key: Groq API key. If None, reads from GROQ_API_KEY
                 environment variable. If both are None, fallback mode is
                 enabled (only template responses).
-            model_name: Gemini model identifier.
+            model_name: Groq model identifier. If None, reads from
+                GROQ_MODEL environment variable. Defaults to
+                "llama-3.1-8b-instant".
             max_context_docs: Number of retrieved documents to include
                 in the LLM context window.
         """
-        self.api_key = api_key or os.environ.get("GEMINI_API_KEY")
-        self.model_name = model_name
+        self.api_key = api_key or os.environ.get("GROQ_API_KEY")
+        self.model_name = (
+            model_name
+            or os.environ.get("GROQ_MODEL")
+            or "llama-3.1-8b-instant"
+        )
         self.max_context_docs = max_context_docs
         self._client = None
 
         if self.api_key:
             try:
-                try:
-                    import google.genai as genai
-                except ImportError:
-                    import google.generativeai as genai
-                genai.configure(api_key=self.api_key)
-                self._client = genai
-                logger.info("Gemini API initialized with model %s", model_name)
+                from groq import Groq
+                self._client = Groq(api_key=self.api_key)
+                logger.info("Groq API initialized (model: %s)", self.model_name)
             except ImportError:
                 logger.warning(
-                    "google-genai or google-generativeai not installed. "
+                    "groq package not installed. "
                     "RAG will use template fallback only."
                 )
             except Exception as exc:
-                logger.warning("Failed to initialize Gemini API: %s", exc)
+                logger.warning("Failed to initialize Groq API: %s", exc)
 
     # ------------------------------------------------------------------
     # Public API — BaseRAG contract
@@ -111,7 +113,7 @@ class RAGService(BaseRAG):
         context_block = build_context_block(retrieved_docs, max_docs=n_docs)
         prompt = render_prompt(profile_config, query.text, context_block)
 
-        answer, used_llm, model_used = self._call_gemini(prompt)
+        answer, used_llm, model_used = self._call_llm(prompt)
 
         if not used_llm:
             answer = build_fallback_response(
@@ -128,43 +130,44 @@ class RAGService(BaseRAG):
         )
 
     # ------------------------------------------------------------------
-    # Gemini integration
+    # Groq integration
     # ------------------------------------------------------------------
 
-    def _call_gemini(self, prompt: str) -> tuple[str, bool, str]:
-        """Call the Gemini API to generate a response.
+    def _call_llm(self, prompt: str) -> tuple[str, bool, str]:
+        """Call the Groq API to generate a response.
 
         Args:
             prompt: Complete rendered prompt string.
 
         Returns:
             Tuple of (answer_text, used_llm, model_name).
-            If Gemini is unavailable, used_llm=False and answer_text is "".
+            If Groq is unavailable, used_llm=False and answer_text is "".
         """
         if not self._client:
-            logger.debug("Gemini API not available; using template fallback")
+            logger.debug("Groq API not available; using template fallback")
             return "", False, _FALLBACK_MODEL_NAME
 
         try:
-            logger.debug("Calling Gemini API with model %s", self.model_name)
-            model = self._client.GenerativeModel(self.model_name)
-            response = model.generate_content(
-                prompt,
-                generation_config=self._client.types.GenerationConfig(
-                    temperature=0.3,
-                    top_p=0.9,
-                    max_output_tokens=512,
-                ),
+            logger.debug("Calling Groq API with model %s", self.model_name)
+
+            response = self._client.chat.completions.create(
+                model=self.model_name,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.3,
+                top_p=0.9,
+                max_tokens=512,
             )
-            answer = response.text.strip() if response.text else ""
-            logger.info("Gemini response received (%d chars)", len(answer))
+            answer = response.choices[0].message.content or ""
+            answer = answer.strip()
+
+            logger.info("Groq response received (%d chars)", len(answer))
             if not answer:
-                logger.warning("Gemini returned an empty response")
+                logger.warning("Groq returned an empty response")
                 return "", False, _FALLBACK_MODEL_NAME
             return answer, True, self.model_name
 
         except Exception as exc:
-            logger.error("Gemini API call failed: %s — using template fallback", exc)
+            logger.error("Groq API call failed: %s — using template fallback", exc)
             return "", False, _FALLBACK_MODEL_NAME
 
     # ------------------------------------------------------------------
@@ -172,10 +175,10 @@ class RAGService(BaseRAG):
     # ------------------------------------------------------------------
 
     def is_available(self) -> bool:
-        """Check if Gemini API is configured and ready.
+        """Check if Groq API is configured and ready.
 
         Returns:
-            True if API key is set and google-generativeai is available.
+            True if API key is set and groq client is available.
         """
         return bool(self._client and self.api_key)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ chromadb>=0.5.0
 langchain>=0.1.0
 langchain-community>=0.0.0
 python-dotenv>=1.0.0
-google-generativeai>=0.3.0     # Gemini API for profile-aware RAG
+groq>=0.11.0                     # Groq API for profile-aware RAG
 
 # Web crawling
 requests>=2.31.0

--- a/tests/integration/test_rag_pipeline.py
+++ b/tests/integration/test_rag_pipeline.py
@@ -11,10 +11,10 @@ from modules.rag.service import RAGService
 
 
 class TestRAGWithoutLLM:
-    """Test RAG module with fallback (no Gemini API required)."""
+    """Test RAG module with fallback (no Groq API required)."""
 
     def test_rag_generates_response_with_fallback(self):
-        """RAG should generate a response even without Gemini API."""
+        """RAG should generate a response even without Groq API."""
         rag = RAGService(api_key=None)
         docs = [
             RetrievedDocument(

--- a/tests/unit/test_rag_service.py
+++ b/tests/unit/test_rag_service.py
@@ -1,4 +1,4 @@
-"""Tests for RAGService — Gemini integration with fallback."""
+"""Tests for RAGService — Groq integration with fallback."""
 
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +25,7 @@ def _make_query(text="diabetes síntomas", profile_type=UserProfileType.PATIENT)
 
 
 class TestRAGServiceFallback:
-    """Test template fallback when Gemini is unavailable."""
+    """Test template fallback when Groq is unavailable."""
 
     def test_fallback_when_no_api_key(self):
         """Service without API key should use fallback."""
@@ -62,30 +62,29 @@ class TestRAGServiceFallback:
         assert len(response_student.answer) > 0
 
 
-class TestRAGServiceGeminiSuccess:
-    """Test happy path with mocked Gemini response."""
+class TestRAGServiceGroqSuccess:
+    """Test happy path with mocked Groq response."""
 
     def test_generate_uses_llm_when_available(self):
-        """Mock Gemini to return a successful response."""
-        with patch("modules.rag.service.os.environ.get") as mock_env:
-            mock_env.return_value = "fake-api-key"
+        """Mock Groq to return a successful response."""
+        with patch("groq.Groq") as mock_groq_class:
+            mock_client = MagicMock()
+            mock_groq_class.return_value = mock_client
 
-            with patch("modules.rag.service.genai") as mock_genai:
-                mock_model = MagicMock()
-                mock_response = MagicMock()
-                mock_response.text = "La diabetes es una enfermedad metabólica..."
-                mock_model.generate_content.return_value = mock_response
-                mock_genai.GenerativeModel.return_value = mock_model
+            mock_response = MagicMock()
+            mock_choice = MagicMock()
+            mock_choice.message.content = "La diabetes es una enfermedad metabólica..."
+            mock_response.choices = [mock_choice]
+            mock_client.chat.completions.create.return_value = mock_response
 
-                service = RAGService(api_key="fake-api-key")
-                service._client = mock_genai
-                query = _make_query()
-                docs = [_make_retrieved()]
-                response = service.generate(query, docs)
+            service = RAGService(api_key="fake-api-key")
+            query = _make_query()
+            docs = [_make_retrieved()]
+            response = service.generate(query, docs)
 
         assert response.used_llm is True
         assert "diabetes" in response.answer.lower() or len(response.answer) > 0
-        assert response.model_name == "gemini-1.5-flash"
+        assert response.model_name == "llama-3.1-8b-instant"
 
     def test_generate_with_no_user_profile_defaults_to_patient(self):
         service = RAGService(api_key=None)
@@ -109,13 +108,12 @@ class TestRAGServiceAvailability:
         assert service.is_available() is False
 
     def test_is_available_returns_true_with_api_key_and_client(self):
-        with patch("modules.rag.service.os.environ.get") as mock_env:
-            mock_env.return_value = "fake-key"
+        with patch("groq.Groq") as mock_groq_class:
+            mock_client = MagicMock()
+            mock_groq_class.return_value = mock_client
 
-            with patch("modules.rag.service.genai") as mock_genai:
-                service = RAGService(api_key="fake-key")
-                service._client = mock_genai
-                assert service.is_available() is True
+            service = RAGService(api_key="fake-key")
+            assert service.is_available() is True
 
 
 class TestRAGServiceProfileResolution:


### PR DESCRIPTION
- Replace google-genai backend with Groq (OpenAI-compatible)
- Update RAGService to use Groq client and configuration
- Adjust environment variables from GEMINI_API_KEY to GROQ_API_KEY
- Update default model to llama-3.1-8b-instant
- Simplify API initialization by removing google SDK fallback
- Update documentation and tests for Groq integration