### PR TITLE
Refactor collection constants and implement internet search fallback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -42,7 +42,9 @@ from infra.chroma_repository import ChromaRepository
 from modules.document_loader.service import DocumentLoader, DocumentLoaderError
 from modules.indexer.document_store import FileSystemDocumentStore
 from modules.indexer.service import IndexerService
+from modules.retriever.fallback_retriever import FallbackRetriever
 from modules.retriever.service import LSIRetriever
+from modules.web_search import InternetSearchRetriever, WebContentFetcher
 from modules.text_processor.service import TextProcessor
 from modules.rag.service import RAGService
 from tests._synthetic_corpus import RAW_DOCUMENTS
@@ -142,10 +144,19 @@ class Pipeline:
             collection_name="medical_documents",
         )
         self.document_store = FileSystemDocumentStore(storage_dir=_STORE_DIR)
-        self.retriever = LSIRetriever(
+        _lsi = LSIRetriever(
             repository=self.repository,
             document_store=self.document_store,
             model_dir=_MODELS_DIR,
+        )
+        _internet = InternetSearchRetriever(
+            fetcher=WebContentFetcher(),
+            document_store=self.document_store,
+        )
+        self.retriever = FallbackRetriever(
+            primary=_lsi,
+            fallback=_internet,
+            min_results=3,
         )
         self.context = RetrievalContext(strategy=self.retriever)
         self.rag_service = RAGService()

--- a/infra/chroma_repository.py
+++ b/infra/chroma_repository.py
@@ -2,12 +2,21 @@
 
 This repository stores only document IDs, embeddings, and minimal metadata (URLs).
 Full document text is stored separately in a DocumentStore implementation.
+
+Collection naming convention:
+    CORPUS_COLLECTION     — curated documents indexed from the crawler.
+    WEB_SEARCH_COLLECTION — documents fetched from external web searches (future).
+    Never mix both sources in the same collection.
 """
 
 import chromadb
 
 from core.interfaces import BaseRepository
 from core.models import Document
+
+# ChromaDB collection names — one per data source to prevent corpus contamination.
+CORPUS_COLLECTION = "corpus_curated"
+WEB_SEARCH_COLLECTION = "web_search_results"
 
 
 class ChromaRepository(BaseRepository):
@@ -20,12 +29,15 @@ class ChromaRepository(BaseRepository):
 
     Full document text is stored separately in a DocumentStore.
     This separation improves scalability and reduces vector DB costs.
+
+    Use CORPUS_COLLECTION for the curated crawler corpus and
+    WEB_SEARCH_COLLECTION for any externally fetched web documents.
     """
 
     def __init__(
         self,
         persist_directory: str = "data/chroma",
-        collection_name: str = "medical_documents",
+        collection_name: str = CORPUS_COLLECTION,
     ) -> None:
         """Initialize ChromaDB client and collection.
 

--- a/modules/indexer/document_store.py
+++ b/modules/indexer/document_store.py
@@ -58,12 +58,17 @@ class FileSystemDocumentStore(DocumentStore):
 
     For production scale (>100K documents), consider migrating to SQLite or PostgreSQL.
 
+    Storage directory convention:
+        data/documents/corpus/     — curated crawler documents (default).
+        data/documents/web_search/ — externally fetched web documents (future).
+        Keep these separate to avoid contaminating the curated corpus.
+
     Raises:
         DocumentWriteError: When a document cannot be saved to disk.
         DocumentReadError: When a document cannot be read from disk.
     """
 
-    def __init__(self, storage_dir: str = "data/documents") -> None:
+    def __init__(self, storage_dir: str = "data/documents/corpus") -> None:
         """Initialize the document store.
 
         Args:

--- a/modules/indexer/document_store.py
+++ b/modules/indexer/document_store.py
@@ -225,6 +225,28 @@ class FileSystemDocumentStore(DocumentStore):
                 f"Cannot delete document '{doc_id}': {e}"
             ) from e
 
+    def list_all_ids(self) -> list[str]:
+        """List all document IDs stored in the filesystem.
+
+        Iterates over every JSON file in the storage directory and reads the
+        ``doc_id`` field from each one. Hashed filenames are handled transparently
+        because the original ID is always written inside the JSON body.
+
+        Returns:
+            List of document IDs found in storage. Order is filesystem-dependent.
+        """
+        ids: list[str] = []
+        for json_file in self.storage_dir.glob("*.json"):
+            try:
+                with open(json_file, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                    ids.append(data["doc_id"])
+            except (json.JSONDecodeError, KeyError, OSError) as e:
+                logger.debug(
+                    "list_all_ids: skipping unreadable file '%s': %s", json_file.name, e
+                )
+        return ids
+
     def _get_document_path(self, doc_id: str) -> Path:
         """Compute a safe filesystem path for a document ID.
 

--- a/modules/retriever/fallback_retriever.py
+++ b/modules/retriever/fallback_retriever.py
@@ -1,0 +1,186 @@
+"""Fallback retriever — chains a primary and a secondary retrieval strategy.
+
+When the primary retriever (LSI) returns fewer than ``min_results`` documents,
+the fallback retriever is activated and its results are appended. Duplicate
+documents (same ``doc_id``) are deduplicated, keeping the higher score.
+
+Typical wiring:
+    primary  = LSIRetriever(...)        # fast, corpus-local
+    fallback = InternetSearchRetriever(...) # slower, internet-based
+
+    retriever = FallbackRetriever(
+        primary=primary,
+        fallback=fallback,
+        min_results=3,   # activate internet search if LSI returns < 3 docs
+    )
+
+The ``FallbackRetriever`` itself implements ``BaseRetriever`` so it can be
+dropped in anywhere a retriever is expected.
+
+Usage:
+    results = retriever.retrieve(query, top_k=10)
+    # Returns up to top_k documents. Primary results appear first,
+    # fallback results are appended after deduplication.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.interfaces import BaseRetriever
+from core.models import Query, RetrievedDocument
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackRetriever(BaseRetriever):
+    """Chains two retrievers: primary first, fallback when primary is insufficient.
+
+    Strategy:
+        1. Run the primary retriever (e.g., LSI) with the full ``top_k`` budget.
+        2. If the number of results is below ``min_results``, run the fallback
+           (e.g., internet search) to supplement.
+        3. Merge results, deduplicate by ``doc_id`` (keeping the higher score),
+           sort by score descending, and return up to ``top_k`` documents.
+
+    This keeps the primary retriever fast for the common case where the local
+    corpus has enough relevant content, and only pays the cost of internet
+    search when truly needed.
+
+    Attributes:
+        primary: Main retrieval strategy (typically LSI-based).
+        fallback: Secondary strategy activated when primary is insufficient.
+        min_results: Threshold below which the fallback is triggered.
+            If ``primary`` returns fewer than this many documents, ``fallback``
+            is also called and its results are merged in.
+    """
+
+    def __init__(
+        self,
+        primary: BaseRetriever,
+        fallback: BaseRetriever,
+        min_results: int = 3,
+    ) -> None:
+        """Initialize with a primary and fallback retriever.
+
+        Args:
+            primary: Retriever to try first (e.g., ``LSIRetriever``).
+            fallback: Retriever to activate if primary returns too few results
+                (e.g., ``InternetSearchRetriever``).
+            min_results: Minimum number of results from ``primary`` before the
+                fallback is skipped. Defaults to 3.
+        """
+        self.primary = primary
+        self.fallback = fallback
+        self.min_results = min_results
+
+    def retrieve(self, query: Query, top_k: int = 10) -> list[RetrievedDocument]:
+        """Retrieve documents using primary strategy with optional fallback.
+
+        Args:
+            query: User query passed to both retrievers.
+            top_k: Maximum number of results to return overall.
+
+        Returns:
+            Merged, deduplicated list of documents sorted by score (descending).
+            Primary results are preferred when the same document appears in both.
+        """
+        # Phase 1: primary retrieval
+        primary_results = self._run_primary(query, top_k)
+
+        if len(primary_results) >= self.min_results:
+            logger.debug(
+                "FallbackRetriever: primary returned %d results (>= min_results=%d), "
+                "skipping fallback for query='%s'",
+                len(primary_results), self.min_results, query.text,
+            )
+            return primary_results[:top_k]
+
+        # Phase 2: fallback retrieval
+        logger.info(
+            "FallbackRetriever: primary returned %d results (< min_results=%d), "
+            "activating fallback for query='%s'",
+            len(primary_results), self.min_results, query.text,
+        )
+        fallback_results = self._run_fallback(query, top_k)
+
+        merged = self._merge(primary_results, fallback_results, top_k)
+        logger.info(
+            "FallbackRetriever: merged %d primary + %d fallback → %d total results",
+            len(primary_results), len(fallback_results), len(merged),
+        )
+        return merged
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _run_primary(self, query: Query, top_k: int) -> list[RetrievedDocument]:
+        """Run the primary retriever, returning [] on any error.
+
+        Args:
+            query: User query.
+            top_k: Budget for primary retriever.
+
+        Returns:
+            List of retrieved documents (may be empty).
+        """
+        try:
+            return self.primary.retrieve(query, top_k=top_k)
+        except Exception as e:
+            logger.warning(
+                "FallbackRetriever: primary retriever failed: %s", e
+            )
+            return []
+
+    def _run_fallback(self, query: Query, top_k: int) -> list[RetrievedDocument]:
+        """Run the fallback retriever, returning [] on any error.
+
+        Args:
+            query: User query.
+            top_k: Budget for fallback retriever.
+
+        Returns:
+            List of retrieved documents (may be empty).
+        """
+        try:
+            return self.fallback.retrieve(query, top_k=top_k)
+        except Exception as e:
+            logger.warning(
+                "FallbackRetriever: fallback retriever failed: %s", e
+            )
+            return []
+
+    @staticmethod
+    def _merge(
+        primary: list[RetrievedDocument],
+        fallback: list[RetrievedDocument],
+        top_k: int,
+    ) -> list[RetrievedDocument]:
+        """Merge two result lists, deduplicate by doc_id, sort by score.
+
+        When the same document appears in both lists, the entry with the
+        higher score is kept.
+
+        Args:
+            primary: Results from the primary retriever.
+            fallback: Results from the fallback retriever.
+            top_k: Maximum number of documents to return.
+
+        Returns:
+            Merged, deduplicated list sorted by score descending.
+        """
+        seen: dict[str, RetrievedDocument] = {}
+
+        for result in primary:
+            doc_id = result.document.doc_id
+            if doc_id not in seen or result.score > seen[doc_id].score:
+                seen[doc_id] = result
+
+        for result in fallback:
+            doc_id = result.document.doc_id
+            if doc_id not in seen or result.score > seen[doc_id].score:
+                seen[doc_id] = result
+
+        merged = sorted(seen.values(), key=lambda r: r.score, reverse=True)
+        return merged[:top_k]

--- a/modules/retriever/service.py
+++ b/modules/retriever/service.py
@@ -33,7 +33,7 @@ class LSIRetriever(BaseRetriever):
     """
 
     # Default similarity threshold - results below this score are filtered out
-    DEFAULT_SIMILARITY_THRESHOLD = 0.1
+    DEFAULT_SIMILARITY_THRESHOLD = 0.25
 
     def __init__(
         self,
@@ -52,7 +52,7 @@ class LSIRetriever(BaseRetriever):
             n_components: Number of latent LSI dimensions.
             similarity_threshold: Minimum similarity score (0-1) for results.
                 Results below this threshold are filtered out. If None, uses
-                DEFAULT_SIMILARITY_THRESHOLD (0.4).
+                DEFAULT_SIMILARITY_THRESHOLD (0.25).
         """
         self.repository = repository
         self.document_store = document_store

--- a/modules/web_search/__init__.py
+++ b/modules/web_search/__init__.py
@@ -1,10 +1,28 @@
-"""Web search fallback module for the SRI pipeline.
+"""Web search module for the SRI pipeline.
 
-This module provides document retrieval when the LSI retriever does not return
-sufficient results. It performs keyword-based search across the document corpus
-to find relevant medical documents.
+Provides two retrieval strategies:
+
+    WebSearchRetriever    — keyword-based fallback over the *local* corpus.
+                            Fast, no network required.
+
+    InternetSearchRetriever — searches DuckDuckGo and downloads real pages.
+                              Used when local corpus lacks enough information.
+
+    WebContentFetcher     — low-level component used by InternetSearchRetriever.
+                            Can be used standalone for web content acquisition.
+
+Typical wiring (see FallbackRetriever in modules.retriever):
+    fetcher = WebContentFetcher()
+    internet = InternetSearchRetriever(fetcher, document_store=cache)
+    retriever = FallbackRetriever(primary=lsi_retriever, fallback=internet, min_results=3)
 """
 
+from .fetcher import WebContentFetcher
+from .internet_retriever import InternetSearchRetriever
 from .service import WebSearchRetriever
 
-__all__ = ["WebSearchRetriever"]
+__all__ = [
+    "WebSearchRetriever",
+    "WebContentFetcher",
+    "InternetSearchRetriever",
+]

--- a/modules/web_search/fetcher.py
+++ b/modules/web_search/fetcher.py
@@ -1,0 +1,287 @@
+"""Web content fetcher — downloads pages found via DuckDuckGo search.
+
+Performs two steps for each query:
+    1. Search: use the DuckDuckGo API (no API key required) to get a list of
+       relevant URLs and titles.
+    2. Fetch: download each page with ``requests`` and extract clean text
+       using ``BeautifulSoup``.
+
+The resulting ``Document`` objects have the fetched page text as their body
+and can be passed directly into any ``BaseRetriever`` or persisted via a
+``DocumentStore`` for caching.
+
+Usage:
+    fetcher = WebContentFetcher(max_text_length=8000, request_timeout=10)
+    docs = fetcher.fetch("hypertension treatment guidelines", max_results=5)
+    for doc in docs:
+        print(doc.url, len(doc.text))
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from typing import TYPE_CHECKING
+
+import requests
+from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    from core.models import Document
+
+logger = logging.getLogger(__name__)
+
+# Tags whose content is always noise — remove before text extraction.
+_NOISE_TAGS = [
+    "script", "style", "noscript", "header", "footer", "nav",
+    "aside", "form", "button", "iframe", "svg", "img",
+]
+
+# Default user-agent to identify the crawler politely.
+_USER_AGENT = (
+    "ShealtRI-Crawler/1.0 (Medical information retrieval research project; "
+    "educational use only)"
+)
+
+
+class WebContentFetcher:
+    """Searches DuckDuckGo and fetches page content for a text query.
+
+    Each call to ``fetch()`` returns a list of ``Document`` objects built from
+    the pages found by DuckDuckGo. Pages that time out, return HTTP errors, or
+    contain too little text are skipped gracefully.
+
+    Attributes:
+        request_timeout: Seconds to wait before aborting a page download.
+        max_text_length: Maximum number of characters to keep from each page.
+            Truncation happens at a word boundary when possible.
+        min_text_length: Pages with fewer characters after cleaning are skipped.
+        user_agent: HTTP User-Agent header sent with every request.
+    """
+
+    def __init__(
+        self,
+        request_timeout: int = 10,
+        max_text_length: int = 8000,
+        min_text_length: int = 200,
+        user_agent: str = _USER_AGENT,
+    ) -> None:
+        """Initialize the fetcher.
+
+        Args:
+            request_timeout: HTTP request timeout in seconds.
+            max_text_length: Max characters to keep per fetched page.
+            min_text_length: Minimum characters required to keep a page.
+            user_agent: User-Agent header for HTTP requests.
+        """
+        self.request_timeout = request_timeout
+        self.max_text_length = max_text_length
+        self.min_text_length = min_text_length
+        self._session = requests.Session()
+        self._session.headers.update({"User-Agent": user_agent})
+
+    def fetch(self, query: str, max_results: int = 5) -> list[Document]:
+        """Search DuckDuckGo and fetch content from the result pages.
+
+        Args:
+            query: Search query string (plain text, no special operators needed).
+            max_results: Maximum number of pages to download. More results mean
+                better recall but slower response time.
+
+        Returns:
+            List of ``Document`` objects containing the fetched page text.
+            May be shorter than ``max_results`` if some pages fail or are too short.
+        """
+        from core.models import Document  # local import avoids circular deps at module load
+
+        if not query or not query.strip():
+            logger.warning("WebContentFetcher.fetch: empty query, returning []")
+            return []
+
+        search_results = self._search_duckduckgo(query, max_results)
+        if not search_results:
+            logger.warning(
+                "WebContentFetcher: no DuckDuckGo results for query='%s'", query
+            )
+            return []
+
+        documents: list[Document] = []
+        for rank, (url, title, snippet) in enumerate(search_results):
+            doc = self._fetch_page(url, title, snippet, rank)
+            if doc is not None:
+                documents.append(doc)
+
+        logger.info(
+            "WebContentFetcher: fetched %d/%d pages for query='%s'",
+            len(documents), len(search_results), query,
+        )
+        return documents
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _search_duckduckgo(
+        self, query: str, max_results: int
+    ) -> list[tuple[str, str, str]]:
+        """Query DuckDuckGo and return (url, title, snippet) tuples.
+
+        Args:
+            query: Search query.
+            max_results: Maximum number of results to request.
+
+        Returns:
+            List of (url, title, snippet) tuples. Empty list on failure.
+        """
+        try:
+            from duckduckgo_search import DDGS
+
+            with DDGS() as ddgs:
+                raw = list(ddgs.text(query, max_results=max_results))
+
+            results = [
+                (r["href"], r.get("title", ""), r.get("body", ""))
+                for r in raw
+                if r.get("href")
+            ]
+            logger.debug(
+                "DuckDuckGo returned %d results for query='%s'", len(results), query
+            )
+            return results
+
+        except ImportError:
+            logger.error(
+                "duckduckgo_search is not installed. "
+                "Run: pip install duckduckgo-search"
+            )
+            return []
+        except Exception as e:
+            logger.warning("DuckDuckGo search failed for query='%s': %s", query, e)
+            return []
+
+    def _fetch_page(
+        self, url: str, title: str, snippet: str, rank: int
+    ) -> Document | None:
+        """Download a single page and extract its text content.
+
+        Falls back to the DuckDuckGo snippet if the page cannot be downloaded.
+
+        Args:
+            url: Page URL to fetch.
+            title: Page title from DuckDuckGo (used in metadata).
+            snippet: DuckDuckGo result snippet (fallback if page fetch fails).
+            rank: Zero-based result rank (used for doc_id generation).
+
+        Returns:
+            Document with extracted text, or None if the page is too short.
+        """
+        from core.models import Document
+
+        text = self._download_text(url)
+
+        if text is None:
+            # Fall back to the snippet from DuckDuckGo
+            if snippet and len(snippet) >= self.min_text_length:
+                text = snippet
+                logger.debug("WebContentFetcher: using snippet fallback for %s", url)
+            else:
+                logger.debug(
+                    "WebContentFetcher: skipping %s (fetch failed, snippet too short)",
+                    url,
+                )
+                return None
+
+        if len(text) < self.min_text_length:
+            logger.debug(
+                "WebContentFetcher: skipping %s (text too short: %d chars)", url, len(text)
+            )
+            return None
+
+        # Truncate at word boundary
+        if len(text) > self.max_text_length:
+            text = text[: self.max_text_length].rsplit(" ", 1)[0]
+
+        doc_id = self._make_doc_id(url)
+        return Document(
+            doc_id=doc_id,
+            text=text,
+            url=url,
+            metadata={
+                "title": title,
+                "source": "web_search",
+                "rank": rank,
+            },
+        )
+
+    def _download_text(self, url: str) -> str | None:
+        """Download a URL and extract readable text from its HTML.
+
+        Args:
+            url: Page URL.
+
+        Returns:
+            Cleaned page text, or None on network/parsing error.
+        """
+        try:
+            response = self._session.get(
+                url, timeout=self.request_timeout, allow_redirects=True
+            )
+            response.raise_for_status()
+
+            content_type = response.headers.get("Content-Type", "")
+            if "text/html" not in content_type and "text/plain" not in content_type:
+                logger.debug(
+                    "WebContentFetcher: skipping non-HTML response at %s (%s)",
+                    url, content_type,
+                )
+                return None
+
+            return self._extract_text(response.text)
+
+        except requests.exceptions.Timeout:
+            logger.debug("WebContentFetcher: timeout fetching %s", url)
+            return None
+        except requests.exceptions.RequestException as e:
+            logger.debug("WebContentFetcher: request error for %s: %s", url, e)
+            return None
+
+    def _extract_text(self, html: str) -> str:
+        """Parse HTML and extract clean readable text.
+
+        Removes script/style/nav tags, collapses whitespace, and
+        returns the body text.
+
+        Args:
+            html: Raw HTML string.
+
+        Returns:
+            Cleaned plain text.
+        """
+        soup = BeautifulSoup(html, "lxml")
+
+        # Remove noise tags
+        for tag in soup.find_all(_NOISE_TAGS):
+            tag.decompose()
+
+        # Prefer article or main content, fall back to body
+        content = soup.find("article") or soup.find("main") or soup.body
+        if content is None:
+            return ""
+
+        # Get text and collapse whitespace
+        raw_text = content.get_text(separator=" ")
+        text = re.sub(r"\s+", " ", raw_text).strip()
+        return text
+
+    @staticmethod
+    def _make_doc_id(url: str) -> str:
+        """Generate a stable, filesystem-safe document ID from a URL.
+
+        Args:
+            url: Source URL.
+
+        Returns:
+            Hex-encoded SHA-256 prefix of the URL (16 chars, collision-resistant).
+        """
+        return "web_" + hashlib.sha256(url.encode("utf-8")).hexdigest()[:24]

--- a/modules/web_search/internet_retriever.py
+++ b/modules/web_search/internet_retriever.py
@@ -1,0 +1,131 @@
+"""Internet-based retriever — fetches real web content for a query.
+
+This retriever calls DuckDuckGo and downloads the resulting pages to build
+``RetrievedDocument`` objects on the fly. It is intended to be used as a
+fallback when the local LSI retriever cannot find enough relevant documents.
+
+Optionally, fetched documents are persisted in a ``DocumentStore`` so that
+repeated identical queries hit the cache instead of the network.
+
+Usage:
+    fetcher = WebContentFetcher()
+    cache = FileSystemDocumentStore("data/documents/web_search")
+    retriever = InternetSearchRetriever(fetcher, document_store=cache)
+
+    results = retriever.retrieve(Query(text="hypertension causes"), top_k=5)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from core.interfaces import BaseRetriever, DocumentStore
+from core.models import Query, RetrievedDocument
+from modules.web_search.fetcher import WebContentFetcher
+
+if TYPE_CHECKING:
+    from core.models import Document
+
+logger = logging.getLogger(__name__)
+
+
+class InternetSearchRetriever(BaseRetriever):
+    """Retriever that performs live internet searches via DuckDuckGo.
+
+    For each query the retriever:
+        1. Calls ``WebContentFetcher.fetch()`` to get pages from the web.
+        2. Assigns rank-based relevance scores (first result scores highest).
+        3. Optionally persists fetched documents in a ``DocumentStore`` cache.
+
+    Scores are rank-based: the first result gets score 1.0 and they decay
+    linearly, so the k-th result scores 1 - (k / (top_k + 1)).
+
+    Attributes:
+        fetcher: Component that handles DuckDuckGo search + page download.
+        document_store: Optional cache to persist fetched documents.
+            If provided, new docs are added after each successful fetch.
+    """
+
+    def __init__(
+        self,
+        fetcher: WebContentFetcher,
+        document_store: DocumentStore | None = None,
+    ) -> None:
+        """Initialize the internet retriever.
+
+        Args:
+            fetcher: ``WebContentFetcher`` instance configured for HTTP timeouts
+                and text extraction.
+            document_store: Optional ``DocumentStore`` to persist fetched
+                documents. Pass ``None`` to disable caching.
+        """
+        self.fetcher = fetcher
+        self.document_store = document_store
+
+    def retrieve(self, query: Query, top_k: int = 10) -> list[RetrievedDocument]:
+        """Fetch pages from the internet for the given query.
+
+        Args:
+            query: User query. Only ``query.text`` is used; ``indexed_corpus``
+                is not needed because this retriever bypasses LSI entirely.
+            top_k: Maximum number of web pages to fetch and return.
+
+        Returns:
+            List of ``RetrievedDocument`` objects with rank-based scores,
+            sorted from highest to lowest relevance. Empty list if the
+            query is empty or all page fetches fail.
+        """
+        if not query.text or not query.text.strip():
+            logger.warning("InternetSearchRetriever: empty query, returning []")
+            return []
+
+        logger.info(
+            "InternetSearchRetriever: searching web for query='%s' (top_k=%d)",
+            query.text, top_k,
+        )
+
+        documents = self.fetcher.fetch(query.text, max_results=top_k)
+        if not documents:
+            logger.warning(
+                "InternetSearchRetriever: no web results for query='%s'", query.text
+            )
+            return []
+
+        # Persist to cache if a store is provided
+        if self.document_store is not None:
+            self._cache_documents(documents)
+
+        # Assign rank-based scores: position 0 → 1.0, position k → decays to 0
+        results = []
+        n = len(documents)
+        for rank, doc in enumerate(documents):
+            score = 1.0 - (rank / (n + 1))
+            results.append(RetrievedDocument(document=doc, score=round(score, 4)))
+
+        logger.info(
+            "InternetSearchRetriever: returning %d results for query='%s'",
+            len(results), query.text,
+        )
+        return results
+
+    def _cache_documents(self, documents: list[Document]) -> None:
+        """Persist fetched documents in the document store, skipping duplicates.
+
+        Args:
+            documents: Freshly fetched documents to cache.
+        """
+        new_docs = [
+            doc for doc in documents
+            if not self.document_store.exists(doc.doc_id)
+        ]
+        if new_docs:
+            try:
+                self.document_store.add_documents(new_docs)
+                logger.debug(
+                    "InternetSearchRetriever: cached %d new web documents", len(new_docs)
+                )
+            except Exception as e:
+                logger.warning(
+                    "InternetSearchRetriever: failed to cache documents: %s", e
+                )

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ groq>=0.11.0                     # Groq API for profile-aware RAG
 requests>=2.31.0
 beautifulsoup4>=4.12.0
 lxml>=4.9.0
+duckduckgo-search>=6.0.0     # DuckDuckGo search (no API key) for internet fallback retrieval
 
 # Document parsing
 pypdf>=3.17.0                # PDF loading for digital books corpus


### PR DESCRIPTION
This pull request introduces a fallback retrieval strategy to improve document search robustness, clarifies storage conventions to prevent data contamination between curated and web-fetched documents, and adjusts retrieval thresholds for better relevance. The most significant changes are grouped below.

**Retrieval Strategy Improvements:**

* Added a new `FallbackRetriever` class that chains a primary retriever (e.g., `LSIRetriever`) with a fallback (e.g., `InternetSearchRetriever`). If the primary returns too few results, the fallback supplements them, with deduplication and score-based sorting. This is now wired into the CLI and can be used wherever a retriever is expected. 
* Updated the web search module (`modules/web_search`) to clarify the distinction between local corpus search and internet-based search, and to expose both `WebContentFetcher` and `InternetSearchRetriever` for integration with fallback strategies.

**Corpus and Storage Separation:**

* Established clear naming and storage conventions to prevent mixing curated (crawler) documents with externally fetched web documents. This includes new constants for ChromaDB collection names (`CORPUS_COLLECTION`, `WEB_SEARCH_COLLECTION`) and separate filesystem directories for each type. 

**Indexer Enhancements:**

* Added a `list_all_ids` method to `FileSystemDocumentStore` to enumerate all stored document IDs, improving document management and diagnostics.

**Retrieval Quality Tuning:**

* Increased the default similarity threshold in `LSIRetriever` to 0.25 (from 0.1), ensuring only more relevant documents are returned by default.